### PR TITLE
Fix a player goroutine blocking when the provider is disabled

### DIFF
--- a/server/player/provider.go
+++ b/server/player/provider.go
@@ -1,6 +1,7 @@
 package player
 
 import (
+	"errors"
 	"github.com/google/uuid"
 	"io"
 )
@@ -29,7 +30,7 @@ func (NopProvider) Save(uuid.UUID, Data) error {
 
 // Load ...
 func (NopProvider) Load(uuid.UUID) (Data, error) {
-	return Data{}, nil
+	return Data{}, errors.New("player provider is not implemented")
 }
 
 // Close ...


### PR DESCRIPTION
Fixes #202

This happened after changing `Load(UUID uuid.UUID) (Data, bool)` to `Load(UUID uuid.UUID) (Data, error)`. The player provider sends empty data but also no error so all these nil values will get assigned to the player.