### PR TITLE
Leftover code? block.Beacon.UseOnBlock()

### DIFF
--- a/server/block/beacon.go
+++ b/server/block/beacon.go
@@ -32,17 +32,6 @@ func (b Beacon) BreakInfo() BreakInfo {
 	return newBreakInfo(3, alwaysHarvestable, nothingEffective, oneOf(b))
 }
 
-// UseOnBlock ...
-func (b Beacon) UseOnBlock(pos cube.Pos, face cube.Face, _ mgl64.Vec3, w *world.World, user item.User, ctx *item.UseContext) (used bool) {
-	pos, _, used = firstReplaceable(w, pos, face, b)
-	if !used {
-		return
-	}
-
-	place(w, pos, b, user, ctx)
-	return placed(ctx)
-}
-
 // Activate manages the opening of a beacon by activating it.
 func (b Beacon) Activate(pos cube.Pos, _ cube.Face, _ *world.World, u item.User) {
 	if opener, ok := u.(ContainerOpener); ok {


### PR DESCRIPTION
# Removed leftover code block.Beacon.UseOnBlock()
You said that items or blocks have to implement the [UsableOnBlock](https://github.com/df-mc/dragonfly/blob/e0ae99eaf1c2b57ad829f7cc186dd70efbf71ecb/server/item/item.go#L21) interface when they have special logic on interaction. However, I couldn't find the "special logic" of the beacon block.

https://github.com/df-mc/dragonfly/blob/e0ae99eaf1c2b57ad829f7cc186dd70efbf71ecb/server/block/beacon.go#L35-L44
I looked into the source code of the beacon block and asked "aren't all blocks can replace a replaceable block" in Bedrock Gophers Discord. Pig told me that this probably is a leftover code.

![image](https://user-images.githubusercontent.com/53002741/124371966-5bac2180-dcb9-11eb-82b3-a162d59b7e52.png)
