### PR TITLE
Minor improvements toward the usability of chat.Chat

### DIFF
--- a/server/player/chat/chat.go
+++ b/server/player/chat/chat.go
@@ -18,9 +18,9 @@ type Chat struct {
 	subscribers map[Subscriber]struct{}
 }
 
-// New returns a new chat. A zero value is, however, usually sufficient for use.
+// New returns a new chat.
 func New() *Chat {
-	return &Chat{}
+	return &Chat{subscribers: map[Subscriber]struct{}{}}
 }
 
 // Write writes the byte slice p as a string to the chat. It is equivalent to calling

--- a/server/player/chat/chat.go
+++ b/server/player/chat/chat.go
@@ -48,6 +48,14 @@ func (chat *Chat) Subscribe(s Subscriber) {
 	chat.subscribers[s] = struct{}{}
 }
 
+// Subscribed checks if a subscriber is currently subscribed to the chat.
+func (chat *Chat) Subscribed(s Subscriber) bool {
+	chat.m.Lock()
+	defer chat.m.Unlock()
+	_, ok := chat.subscribers[s]
+	return ok
+}
+
 // Unsubscribe removes a subscriber from the chat, so that messages written to the chat will no longer be
 // sent to it.
 func (chat *Chat) Unsubscribe(s Subscriber) {

--- a/server/player/chat/chat.go
+++ b/server/player/chat/chat.go
@@ -33,8 +33,7 @@ func (chat *Chat) Write(p []byte) (n int, err error) {
 func (chat *Chat) WriteString(s string) (n int, err error) {
 	chat.m.Lock()
 	defer chat.m.Unlock()
-
-	for subscriber, _ := range chat.subscribers {
+	for subscriber := range chat.subscribers {
 		subscriber.Message(s)
 	}
 	return len(s), nil


### PR DESCRIPTION
Made a few changes to chat.Chat

Converted Chat.subscriber from a slice into a map for:
- Prevent duplicated subscriber if subscribe is already subscribed
- Easier access to checking and removing subscriber

Added Chat.Subscribed():
- Allows checking if a subscriber subscribed to the chat, or not
- While this is unnecessary if there was only one chat, when juggling with multiple chats, it helps to be able to check and to display as user feedback