### PR TITLE
Fixed form close detection not working

### DIFF
--- a/server/player/form/form.go
+++ b/server/player/form/form.go
@@ -15,7 +15,6 @@ import (
 type Form interface {
 	json.Marshaler
 	SubmitJSON(b []byte, submitter Submitter) error
-	HandleFormClose(submitter Submitter)
 	__()
 }
 
@@ -116,12 +115,6 @@ func (f Custom) SubmitJSON(b []byte, submitter Submitter) error {
 	v.Interface().(Submittable).Submit(submitter)
 
 	return nil
-}
-
-func (f Custom) HandleFormClose(submitter Submitter) {
-	if closer, ok := f.submittable.(Closer); ok {
-		closer.Close(submitter)
-	}
 }
 
 // parseValue parses a value into the Element passed and returns it as a reflect.Value. If the value is not

--- a/server/player/form/form.go
+++ b/server/player/form/form.go
@@ -15,6 +15,7 @@ import (
 type Form interface {
 	json.Marshaler
 	SubmitJSON(b []byte, submitter Submitter) error
+	HandleFormClose(submitter Submitter)
 	__()
 }
 
@@ -115,6 +116,12 @@ func (f Custom) SubmitJSON(b []byte, submitter Submitter) error {
 	v.Interface().(Submittable).Submit(submitter)
 
 	return nil
+}
+
+func (f Custom) HandleFormClose(submitter Submitter) {
+	if closer, ok := f.submittable.(Closer); ok {
+		closer.Close(submitter)
+	}
 }
 
 // parseValue parses a value into the Element passed and returns it as a reflect.Value. If the value is not

--- a/server/player/form/form.go
+++ b/server/player/form/form.go
@@ -118,7 +118,6 @@ func (f Custom) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
-// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.
 func (f Custom) HandleFormClose(submitter Submitter) {
 	if closer, ok := f.submittable.(Closer); ok {
 		closer.Close(submitter)

--- a/server/player/form/form.go
+++ b/server/player/form/form.go
@@ -118,6 +118,7 @@ func (f Custom) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
+// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.
 func (f Custom) HandleFormClose(submitter Submitter) {
 	if closer, ok := f.submittable.(Closer); ok {
 		closer.Close(submitter)

--- a/server/player/form/form.go
+++ b/server/player/form/form.go
@@ -78,6 +78,13 @@ func (f Custom) Elements() []Element {
 // If the values are valid and can be parsed properly, the Submit() method of the form's Submittable is called
 // and the fields of the Submittable will be filled out.
 func (f Custom) SubmitJSON(b []byte, submitter Submitter) error {
+	if b == nil {
+		if closer, ok := f.submittable.(Closer); ok {
+			closer.Close(submitter)
+		}
+		return nil
+	}
+
 	dec := json.NewDecoder(bytes.NewBuffer(b))
 	dec.UseNumber()
 

--- a/server/player/form/menu.go
+++ b/server/player/form/menu.go
@@ -96,12 +96,6 @@ func (m Menu) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
-func (m Menu) HandleFormClose(submitter Submitter) {
-	if closer, ok := m.submittable.(Closer); ok {
-		closer.Close(submitter)
-	}
-}
-
 // verify verifies if the form is valid, checking all fields are of the type Button. It panics if the form is
 // not valid.
 func (m Menu) verify() {

--- a/server/player/form/menu.go
+++ b/server/player/form/menu.go
@@ -83,6 +83,13 @@ func (m Menu) Buttons() []Button {
 
 // SubmitJSON submits a JSON value to the menu, containing the index of the button clicked.
 func (m Menu) SubmitJSON(b []byte, submitter Submitter) error {
+	if b == nil {
+		if closer, ok := m.submittable.(Closer); ok {
+			closer.Close(submitter)
+		}
+		return nil
+	}
+
 	var index uint
 	err := json.Unmarshal(b, &index)
 	if err != nil {

--- a/server/player/form/menu.go
+++ b/server/player/form/menu.go
@@ -96,7 +96,7 @@ func (m Menu) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
-// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.s
+// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.
 func (m Menu) HandleFormClose(submitter Submitter) {
 	if closer, ok := m.submittable.(Closer); ok {
 		closer.Close(submitter)

--- a/server/player/form/menu.go
+++ b/server/player/form/menu.go
@@ -96,6 +96,7 @@ func (m Menu) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
+// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.s
 func (m Menu) HandleFormClose(submitter Submitter) {
 	if closer, ok := m.submittable.(Closer); ok {
 		closer.Close(submitter)

--- a/server/player/form/menu.go
+++ b/server/player/form/menu.go
@@ -96,7 +96,7 @@ func (m Menu) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
-// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.
+// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.s
 func (m Menu) HandleFormClose(submitter Submitter) {
 	if closer, ok := m.submittable.(Closer); ok {
 		closer.Close(submitter)

--- a/server/player/form/menu.go
+++ b/server/player/form/menu.go
@@ -96,6 +96,12 @@ func (m Menu) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
+func (m Menu) HandleFormClose(submitter Submitter) {
+	if closer, ok := m.submittable.(Closer); ok {
+		closer.Close(submitter)
+	}
+}
+
 // verify verifies if the form is valid, checking all fields are of the type Button. It panics if the form is
 // not valid.
 func (m Menu) verify() {

--- a/server/player/form/menu.go
+++ b/server/player/form/menu.go
@@ -96,7 +96,6 @@ func (m Menu) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
-// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.s
 func (m Menu) HandleFormClose(submitter Submitter) {
 	if closer, ok := m.submittable.(Closer); ok {
 		closer.Close(submitter)

--- a/server/player/form/modal.go
+++ b/server/player/form/modal.go
@@ -82,12 +82,6 @@ func (m Modal) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
-func (m Modal) HandleFormClose(submitter Submitter) {
-	if closer, ok := m.submittable.(Closer); ok {
-		closer.Close(submitter)
-	}
-}
-
 // Buttons returns a list of all buttons of the Modal form, which will always be a total of two buttons.
 func (m Modal) Buttons() []Button {
 	v := reflect.ValueOf(m.submittable)

--- a/server/player/form/modal.go
+++ b/server/player/form/modal.go
@@ -82,6 +82,7 @@ func (m Modal) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
+// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.
 func (m Modal) HandleFormClose(submitter Submitter) {
 	if closer, ok := m.submittable.(Closer); ok {
 		closer.Close(submitter)

--- a/server/player/form/modal.go
+++ b/server/player/form/modal.go
@@ -70,6 +70,13 @@ func (m Modal) Body() string {
 // SubmitJSON submits a JSON byte slice to the modal form. This byte slice contains a JSON encoded bool in it,
 // which is used to determine which button was clicked.
 func (m Modal) SubmitJSON(b []byte, submitter Submitter) error {
+	if b == nil {
+		if closer, ok := m.submittable.(Closer); ok {
+			closer.Close(submitter)
+		}
+		return nil
+	}
+
 	var value bool
 	if err := json.Unmarshal(b, &value); err != nil {
 		return fmt.Errorf("error parsing JSON as bool: %w", err)

--- a/server/player/form/modal.go
+++ b/server/player/form/modal.go
@@ -82,6 +82,12 @@ func (m Modal) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
+func (m Modal) HandleFormClose(submitter Submitter) {
+	if closer, ok := m.submittable.(Closer); ok {
+		closer.Close(submitter)
+	}
+}
+
 // Buttons returns a list of all buttons of the Modal form, which will always be a total of two buttons.
 func (m Modal) Buttons() []Button {
 	v := reflect.ValueOf(m.submittable)

--- a/server/player/form/modal.go
+++ b/server/player/form/modal.go
@@ -82,7 +82,6 @@ func (m Modal) SubmitJSON(b []byte, submitter Submitter) error {
 	return nil
 }
 
-// HandleFormClose is called when a form is closed by a Submitter. If the submittable of form is a Closer, it calls the Close method of it.
 func (m Modal) HandleFormClose(submitter Submitter) {
 	if closer, ok := m.submittable.(Closer); ok {
 		closer.Close(submitter)

--- a/server/player/form/submit.go
+++ b/server/player/form/submit.go
@@ -30,6 +30,12 @@ type MenuSubmittable interface {
 // buttons on a Modal form will not have images.
 type ModalSubmittable MenuSubmittable
 
+// Closer represents a form which has special logic when being closed by a Submitter. The struct struct will have its Close method called, when its form is closed.
+type Closer interface {
+	// Close is called when the Submitter closes a form
+	Close()
+}
+
 // Submitter is an entity that is able to submit a form sent to it. It is able to fill out fields in the form
 // which will then be present when handled.
 type Submitter interface {

--- a/server/player/form/submit.go
+++ b/server/player/form/submit.go
@@ -33,7 +33,7 @@ type ModalSubmittable MenuSubmittable
 // Closer represents a form which has special logic when being closed by a Submitter. The struct struct will have its Close method called, when its form is closed.
 type Closer interface {
 	// Close is called when the Submitter closes a form
-	Close()
+	Close(submitter Submitter)
 }
 
 // Submitter is an entity that is able to submit a form sent to it. It is able to fill out fields in the form

--- a/server/player/form/submit.go
+++ b/server/player/form/submit.go
@@ -30,7 +30,7 @@ type MenuSubmittable interface {
 // buttons on a Modal form will not have images.
 type ModalSubmittable MenuSubmittable
 
-// Closer represents a form which has special logic when being closed by a Submitter. The struct struct will have its Close method called, when its form is closed.
+// Closer represents a form which has special logic when being closed by a Submitter. The form will have its Close method called, when it is closed.
 type Closer interface {
 	// Close is called when the Submitter closes a form
 	Close(submitter Submitter)

--- a/server/player/form/submit.go
+++ b/server/player/form/submit.go
@@ -30,9 +30,9 @@ type MenuSubmittable interface {
 // buttons on a Modal form will not have images.
 type ModalSubmittable MenuSubmittable
 
-// Closer represents a form which has special logic when being closed by a Submitter. The form will have its Close method called, when it is closed.
+// Closer represents a form which has special logic when being closed by a Submitter.
 type Closer interface {
-	// Close is called when the Submitter closes a form
+	// Close is called when the Submitter closes a form.
 	Close(submitter Submitter)
 }
 

--- a/server/session/handler_modal_form_response.go
+++ b/server/session/handler_modal_form_response.go
@@ -30,8 +30,8 @@ func (h *ModalFormResponseHandler) Handle(p packet.Packet, s *Session) error {
 
 	if bytes.Equal(pk.ResponseData, nullBytes) || len(pk.ResponseData) == 0 {
 		// The form was cancelled: The cross in the top right corner was clicked.
-		if closer, ok := f.(form.Closer); ok {
-			closer.Close(s.c)
+		if err := f.SubmitJSON(nil, s.c); err != nil {
+			return fmt.Errorf("error submitting form data: %w", err)
 		}
 		return nil
 	}

--- a/server/session/handler_modal_form_response.go
+++ b/server/session/handler_modal_form_response.go
@@ -30,6 +30,9 @@ func (h *ModalFormResponseHandler) Handle(p packet.Packet, s *Session) error {
 
 	if bytes.Equal(pk.ResponseData, nullBytes) || len(pk.ResponseData) == 0 {
 		// The form was cancelled: The cross in the top right corner was clicked.
+		if closer, ok := f.(form.Closer); ok {
+			closer.Close(s.c)
+		}
 		return nil
 	}
 	if !ok {

--- a/server/session/handler_modal_form_response.go
+++ b/server/session/handler_modal_form_response.go
@@ -30,10 +30,7 @@ func (h *ModalFormResponseHandler) Handle(p packet.Packet, s *Session) error {
 
 	if bytes.Equal(pk.ResponseData, nullBytes) || len(pk.ResponseData) == 0 {
 		// The form was cancelled: The cross in the top right corner was clicked.
-		if err := f.SubmitJSON(nil, s.c); err != nil {
-			return fmt.Errorf("error handling form close: %w", err)
-		}
-		return nil
+		pk.ResponseData = nil
 	}
 	if !ok {
 		return fmt.Errorf("no form with ID %v currently opened", pk.FormID)

--- a/server/session/handler_modal_form_response.go
+++ b/server/session/handler_modal_form_response.go
@@ -30,7 +30,9 @@ func (h *ModalFormResponseHandler) Handle(p packet.Packet, s *Session) error {
 
 	if bytes.Equal(pk.ResponseData, nullBytes) || len(pk.ResponseData) == 0 {
 		// The form was cancelled: The cross in the top right corner was clicked.
-		f.HandleFormClose(s.c)
+		if closer, ok := f.(form.Closer); ok {
+			closer.Close(s.c)
+		}
 		return nil
 	}
 	if !ok {

--- a/server/session/handler_modal_form_response.go
+++ b/server/session/handler_modal_form_response.go
@@ -31,7 +31,7 @@ func (h *ModalFormResponseHandler) Handle(p packet.Packet, s *Session) error {
 	if bytes.Equal(pk.ResponseData, nullBytes) || len(pk.ResponseData) == 0 {
 		// The form was cancelled: The cross in the top right corner was clicked.
 		if err := f.SubmitJSON(nil, s.c); err != nil {
-			return fmt.Errorf("error submitting form data: %w", err)
+			return fmt.Errorf("error handling form close: %w", err)
 		}
 		return nil
 	}

--- a/server/session/handler_modal_form_response.go
+++ b/server/session/handler_modal_form_response.go
@@ -30,9 +30,7 @@ func (h *ModalFormResponseHandler) Handle(p packet.Packet, s *Session) error {
 
 	if bytes.Equal(pk.ResponseData, nullBytes) || len(pk.ResponseData) == 0 {
 		// The form was cancelled: The cross in the top right corner was clicked.
-		if closer, ok := f.(form.Closer); ok {
-			closer.Close(s.c)
-		}
+		f.HandleFormClose(s.c)
 		return nil
 	}
 	if !ok {


### PR DESCRIPTION
Sorry, I did a small mistake. The code checks if a `form.Form` struct is a Closer, instead of the submittable of it.