### PR TITLE
Fixed animation of block breaking in creative mode

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1279,6 +1279,10 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 
 		p.breaking.Store(true)
 
+		if p.GameMode().CreativeInventory() {
+			return
+		}
+
 		p.SwingArm()
 
 		breakTime := p.breakTime(pos)


### PR DESCRIPTION
I found a bug with animation of block breaking in creative mode when a player extinguishes fire.