### PR TITLE
add command.Allow() function

### DIFF
--- a/server/cmd/command.go
+++ b/server/cmd/command.go
@@ -106,6 +106,17 @@ func (cmd Command) Aliases() []string {
 	return cmd.aliases
 }
 
+// Allow returns whether the provided source is allowed to run the command. It will check each Runnable, and
+// will return true if one or more Runnables allow the source to run the command.
+func (cmd Command) Allow(source Source) bool {
+	for _, runnable := range cmd.v {
+		if allower, ok := runnable.Interface().(Allower); !ok || allower.Allow(source) {
+			return true
+		}
+	}
+	return false
+}
+
 // Execute executes the Command as a source with the args passed. The args are parsed assuming they do not
 // start with the command name. Execute will attempt to parse and execute one Runnable at a time. If one of
 // the Runnable was able to parse args correctly, it will be executed and no more Runnables will be attempted


### PR DESCRIPTION
As mentioned in the documentation of the function, this function essentially checks if the source can use at least one of the Runnables of the command.
An important use for this is for example checking whether or not a command should be included in a /help command (if you implement a custom version of this)
Another use could be for example if you have a commandSpy feature and you want to exclude commands that the player does not have access to.

Currently there is already a way to check this that does essentially the same by checking if `len(command.Params(source)) == 0` but I do not think that is very intuitive in my opinion.