### PR TITLE
add a drops parameter to HandleBlockBreak

### DIFF
--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -55,8 +55,9 @@ type Handler interface {
 	// be called to stop the player from breaking the block completely.
 	HandleStartBreak(ctx *event.Context, pos cube.Pos)
 	// HandleBlockBreak handles a block that is being broken by a player. ctx.Cancel() may be called to cancel
-	// the block being broken.
-	HandleBlockBreak(ctx *event.Context, pos cube.Pos)
+	// the block being broken. A pointer to a slice of the block's drops is passed, and may be altered
+	// to change what items will actually be dropped.
+	HandleBlockBreak(ctx *event.Context, pos cube.Pos, drops *[]item.Stack)
 	// HandleBlockPlace handles the player placing a specific block at a position in its world. ctx.Cancel()
 	// may be called to cancel the block being placed.
 	HandleBlockPlace(ctx *event.Context, pos cube.Pos, b world.Block)
@@ -154,7 +155,7 @@ func (NopHandler) HandleSkinChange(*event.Context, skin.Skin) {}
 func (NopHandler) HandleStartBreak(*event.Context, cube.Pos) {}
 
 // HandleBlockBreak ...
-func (NopHandler) HandleBlockBreak(*event.Context, cube.Pos) {}
+func (NopHandler) HandleBlockBreak(*event.Context, cube.Pos, *[]item.Stack) {}
 
 // HandleBlockPlace ...
 func (NopHandler) HandleBlockPlace(*event.Context, cube.Pos, world.Block) {}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1523,14 +1523,15 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	}
 
 	ctx := event.C()
-	p.handler().HandleBlockBreak(ctx, pos)
+	held, left := p.HeldItems()
+	drops := p.drops(held, b)
+	p.handler().HandleBlockBreak(ctx, pos, &drops)
 
 	ctx.Continue(func() {
 		p.SwingArm()
 		w.BreakBlock(pos)
-		held, left := p.HeldItems()
 
-		for _, drop := range p.drops(held, b) {
+		for _, drop := range drops {
 			itemEntity := entity.NewItem(drop, pos.Vec3Centre())
 			itemEntity.SetVelocity(mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1})
 			w.AddEntity(itemEntity)


### PR DESCRIPTION
This PR makes it possible to alter what items are dropped when a block is mined by a player.