### PR TITLE
Fixed some quartz blocks not appearing in the creative inventory

### DIFF
--- a/server/block/quartz_block.go
+++ b/server/block/quartz_block.go
@@ -84,14 +84,14 @@ func (q QuartzPillar) EncodeItem() (name string, meta int16) {
 // EncodeBlock ...
 func (q Quartz) EncodeBlock() (name string, properties map[string]interface{}) {
 	if q.Smooth {
-		return "minecraft:quartz_block", map[string]interface{}{"chisel_type": "smooth", "pillar_axis": "x"}
+		return "minecraft:quartz_block", map[string]interface{}{"chisel_type": "smooth", "pillar_axis": "y"}
 	}
-	return "minecraft:quartz_block", map[string]interface{}{"chisel_type": "default", "pillar_axis": "x"}
+	return "minecraft:quartz_block", map[string]interface{}{"chisel_type": "default", "pillar_axis": "y"}
 }
 
 // EncodeBlock ...
 func (ChiseledQuartz) EncodeBlock() (name string, properties map[string]interface{}) {
-	return "minecraft:quartz_block", map[string]interface{}{"chisel_type": "chiseled", "pillar_axis": "x"}
+	return "minecraft:quartz_block", map[string]interface{}{"chisel_type": "chiseled", "pillar_axis": "y"}
 }
 
 // EncodeBlock ...


### PR DESCRIPTION
Block of quartz, chiseled quartz block and smooth quartz block wouldn't show up in the creative inventory.
It was caused by the code registering those blocks facing the `x` axis, and the "`x` axis facing" variants of those blocks wouldn't show up in the creative inventory.
It was fixed by just changing the `pillar_axis` value of those blocks to `y`.