### PR TITLE
Fix logic in CalculateOffset functions in AABB

### DIFF
--- a/server/entity/physics/aabb.go
+++ b/server/entity/physics/aabb.go
@@ -176,9 +176,9 @@ func (aabb AABB) Vec3WithinXY(vec mgl64.Vec3) bool {
 // is smaller than 0.
 func (aabb AABB) CalculateXOffset(nearby AABB, deltaX float64) float64 {
 	// Bail out if not within the same Y/Z plane.
-	if nearby.max[1] <= aabb.min[1] || nearby.min[1] >= aabb.max[1] {
+	if aabb.max[1] <= nearby.min[1] || aabb.min[1] >= nearby.max[1] {
 		return deltaX
-	} else if nearby.max[2] <= aabb.min[2] || nearby.min[2] >= aabb.max[2] {
+	} else if aabb.max[2] <= nearby.min[2] || aabb.min[2] >= nearby.max[2] {
 		return deltaX
 	}
 	if deltaX > 0 && nearby.max[0] <= aabb.min[0] {
@@ -201,9 +201,9 @@ func (aabb AABB) CalculateXOffset(nearby AABB, deltaX float64) float64 {
 // is smaller than 0.
 func (aabb AABB) CalculateYOffset(nearby AABB, deltaY float64) float64 {
 	// Bail out if not within the same X/Z plane.
-	if nearby.max[0] <= aabb.min[0] || nearby.min[0] >= aabb.max[0] {
+	if aabb.max[0] <= nearby.min[0] || aabb.min[0] >= nearby.max[0] {
 		return deltaY
-	} else if nearby.max[2] <= aabb.min[2] || nearby.min[2] >= aabb.max[2] {
+	} else if aabb.max[2] <= nearby.min[2] || aabb.min[2] >= nearby.max[2] {
 		return deltaY
 	}
 	if deltaY > 0 && nearby.max[1] <= aabb.min[1] {
@@ -226,9 +226,9 @@ func (aabb AABB) CalculateYOffset(nearby AABB, deltaY float64) float64 {
 // is smaller than 0.
 func (aabb AABB) CalculateZOffset(nearby AABB, deltaZ float64) float64 {
 	// Bail out if not within the same X/Y plane.
-	if nearby.max[0] <= aabb.min[0] || nearby.min[0] >= aabb.max[0] {
+	if aabb.max[0] <= nearby.min[0] || aabb.min[0] >= nearby.max[0] {
 		return deltaZ
-	} else if nearby.max[1] <= aabb.min[1] || nearby.min[1] >= aabb.max[1] {
+	} else if aabb.max[1] <= nearby.min[1] || aabb.min[1] >= nearby.max[1] {
 		return deltaZ
 	}
 	if deltaZ > 0 && nearby.max[2] <= aabb.min[2] {

--- a/server/entity/physics/aabb.go
+++ b/server/entity/physics/aabb.go
@@ -186,8 +186,7 @@ func (aabb AABB) CalculateXOffset(nearby AABB, deltaX float64) float64 {
 		if difference < deltaX {
 			deltaX = difference
 		}
-	}
-	if deltaX < 0 && nearby.min[0] >= aabb.max[0] {
+	} else if deltaX < 0 && nearby.min[0] >= aabb.max[0] {
 		difference := aabb.max[0] - nearby.min[0]
 
 		if difference > deltaX {
@@ -212,8 +211,7 @@ func (aabb AABB) CalculateYOffset(nearby AABB, deltaY float64) float64 {
 		if difference < deltaY {
 			deltaY = difference
 		}
-	}
-	if deltaY < 0 && nearby.min[1] >= aabb.max[1] {
+	} else if deltaY < 0 && nearby.min[1] >= aabb.max[1] {
 		difference := aabb.max[1] - nearby.min[1]
 
 		if difference > deltaY {
@@ -238,8 +236,7 @@ func (aabb AABB) CalculateZOffset(nearby AABB, deltaZ float64) float64 {
 		if difference < deltaZ {
 			deltaZ = difference
 		}
-	}
-	if deltaZ < 0 && nearby.min[2] >= aabb.max[2] {
+	} else if deltaZ < 0 && nearby.min[2] >= aabb.max[2] {
 		difference := aabb.max[2] - nearby.min[2]
 
 		if difference > deltaZ {

--- a/server/entity/physics/aabb.go
+++ b/server/entity/physics/aabb.go
@@ -176,19 +176,19 @@ func (aabb AABB) Vec3WithinXY(vec mgl64.Vec3) bool {
 // is smaller than 0.
 func (aabb AABB) CalculateXOffset(nearby AABB, deltaX float64) float64 {
 	// Bail out if not within the same Y/Z plane.
-	if aabb.max[1] <= nearby.min[1] || aabb.min[1] >= nearby.max[1] {
+	if nearby.max[1] <= aabb.min[1] || nearby.min[1] >= aabb.max[1] {
 		return deltaX
-	} else if aabb.max[2] <= nearby.min[2] || aabb.min[2] >= nearby.max[2] {
+	} else if nearby.max[2] <= aabb.min[2] || nearby.min[2] >= aabb.max[2] {
 		return deltaX
 	}
-	if deltaX > 0 && aabb.max[0] <= nearby.min[0] {
-		difference := nearby.min[0] - aabb.max[0]
+	if deltaX > 0 && nearby.max[0] <= aabb.min[0] {
+		difference := aabb.min[0] - nearby.max[0]
 		if difference < deltaX {
 			deltaX = difference
 		}
 	}
-	if deltaX < 0 && aabb.min[0] >= nearby.max[0] {
-		difference := nearby.max[0] - aabb.min[0]
+	if deltaX < 0 && nearby.min[0] >= aabb.max[0] {
+		difference := aabb.max[0] - nearby.min[0]
 
 		if difference > deltaX {
 			deltaX = difference
@@ -202,19 +202,19 @@ func (aabb AABB) CalculateXOffset(nearby AABB, deltaX float64) float64 {
 // is smaller than 0.
 func (aabb AABB) CalculateYOffset(nearby AABB, deltaY float64) float64 {
 	// Bail out if not within the same X/Z plane.
-	if aabb.max[0] <= nearby.min[0] || aabb.min[0] >= nearby.max[0] {
+	if nearby.max[0] <= aabb.min[0] || nearby.min[0] >= aabb.max[0] {
 		return deltaY
-	} else if aabb.max[2] <= nearby.min[2] || aabb.min[2] >= nearby.max[2] {
+	} else if nearby.max[2] <= aabb.min[2] || nearby.min[2] >= aabb.max[2] {
 		return deltaY
 	}
-	if deltaY > 0 && aabb.max[1] <= nearby.min[1] {
-		difference := nearby.min[1] - aabb.max[1]
+	if deltaY > 0 && nearby.max[1] <= aabb.min[1] {
+		difference := aabb.min[1] - nearby.max[1]
 		if difference < deltaY {
 			deltaY = difference
 		}
 	}
-	if deltaY < 0 && aabb.min[1] >= nearby.max[1] {
-		difference := nearby.max[1] - aabb.min[1]
+	if deltaY < 0 && nearby.min[1] >= aabb.max[1] {
+		difference := aabb.max[1] - nearby.min[1]
 
 		if difference > deltaY {
 			deltaY = difference
@@ -228,19 +228,19 @@ func (aabb AABB) CalculateYOffset(nearby AABB, deltaY float64) float64 {
 // is smaller than 0.
 func (aabb AABB) CalculateZOffset(nearby AABB, deltaZ float64) float64 {
 	// Bail out if not within the same X/Y plane.
-	if aabb.max[0] <= nearby.min[0] || aabb.min[0] >= nearby.max[0] {
+	if nearby.max[0] <= aabb.min[0] || nearby.min[0] >= aabb.max[0] {
 		return deltaZ
-	} else if aabb.max[1] <= nearby.min[1] || aabb.min[1] >= nearby.max[1] {
+	} else if nearby.max[1] <= aabb.min[1] || nearby.min[1] >= aabb.max[1] {
 		return deltaZ
 	}
-	if deltaZ > 0 && aabb.max[2] <= nearby.min[2] {
-		difference := nearby.min[2] - aabb.max[2]
+	if deltaZ > 0 && nearby.max[2] <= aabb.min[2] {
+		difference := aabb.min[2] - nearby.max[2]
 		if difference < deltaZ {
 			deltaZ = difference
 		}
 	}
-	if deltaZ < 0 && aabb.min[2] >= nearby.max[2] {
-		difference := nearby.max[2] - aabb.min[2]
+	if deltaZ < 0 && nearby.min[2] >= aabb.max[2] {
+		difference := aabb.max[2] - nearby.min[2]
 
 		if difference > deltaZ {
 			deltaZ = difference


### PR DESCRIPTION
This fixes the logic in CalculateXOffset, CalculateYOffset, and CalculateZOffset in `aabb.go`

This PR matches the logic in these functions with PM's logic https://github.com/pmmp/Math/blob/stable/src/AxisAlignedBB.php#L276-L340