### PR TITLE
player.go: make ExecuteCommand doc slightly more clear

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -312,7 +312,8 @@ func (p *Player) Chat(msg ...any) {
 }
 
 // ExecuteCommand executes a command passed as the player. If the command could not be found, or if the usage
-// was incorrect, an error message is sent to the player.
+// was incorrect, an error message is sent to the player. This message should start with a "/" for the command to be
+// recognised.
 func (p *Player) ExecuteCommand(commandLine string) {
 	if p.Dead() {
 		return


### PR DESCRIPTION
Should it maybe panic if it does not start with a "/", since i dont think there is any case where it should. I was personally confused as to why my command was not recognised so I felt like this might be an important thing to add to the documentation.