### PR TITLE
Enable the sub-chunk request system because Mojang can't do anything right.

### DIFF
--- a/server/session/chunk.go
+++ b/server/session/chunk.go
@@ -11,9 +11,9 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 )
 
-// subChunkRequests is set to true to enable the sub-chunk request system. This is disabled for now because it is
-// extremely broken in vanilla (as of v1.19.0).
-const subChunkRequests = false
+// subChunkRequests is set to true to enable the sub-chunk request system. This can (likely) cause unexpected issues,
+// but also solves issues with block entities such as item frames and lecterns as of v1.19.10.
+const subChunkRequests = true
 
 // ViewChunk ...
 func (s *Session) ViewChunk(pos world.ChunkPos, c *chunk.Chunk, blockEntities map[cube.Pos]world.Block) {


### PR DESCRIPTION
Resolves #560.