### PR TITLE
Implement partial render_offsets (scale) component

### DIFF
--- a/server/internal/iteminternal/components.go
+++ b/server/internal/iteminternal/components.go
@@ -108,7 +108,7 @@ func Components(it world.CustomItem) map[string]any {
 	return builder.Construct()
 }
 
-// calculateHandPosition calculates the position of the item to be rendered to the player according to the given size.
+// calculateHandPosition calculates the scale of the item to be rendered to the player according to the given size.
 func calculateHandPosition(it world.CustomItem, size float32) (float32, float32, float32) {
 	var x, y, z float32
 	if _, ok := it.(item.HandEquipped); ok {

--- a/server/internal/iteminternal/components.go
+++ b/server/internal/iteminternal/components.go
@@ -81,13 +81,7 @@ func Components(it world.CustomItem) map[string]any {
 	if x, ok := it.(item.HandEquipped); ok {
 		builder.AddProperty("hand_equipped", x.HandEquipped())
 	}
-
-	bounds := it.Texture().Bounds()
-
-	x, y, z := calculateItemScale(it, float32(bounds.Dx()), float32(bounds.Dy()))
-
-	itemScale := []float32{x, y, z}
-
+	itemScale := calculateItemScale(it)
 	builder.AddComponent("minecraft:render_offsets", map[string]any{
 		"main_hand": map[string]any{
 			"first_person": map[string]any{
@@ -111,7 +105,9 @@ func Components(it world.CustomItem) map[string]any {
 }
 
 // calculateItemScale calculates the scale of the item to be rendered to the player according to the given size.
-func calculateItemScale(it world.CustomItem, width, height float32) (float32, float32, float32) {
+func calculateItemScale(it world.CustomItem) []float32 {
+	width := float32(it.Texture().Bounds().Dx())
+	height := float32(it.Texture().Bounds().Dy())
 	var x, y, z float32 = 0.1, 0.1, 0.1
 	if _, ok := it.(item.HandEquipped); ok {
 		x, y, z = 0.075, 0.125, 0.075
@@ -119,5 +115,5 @@ func calculateItemScale(it world.CustomItem, width, height float32) (float32, fl
 	newX := x / (width / 16)
 	newY := y / (height / 16)
 	newZ := z / (width / 16)
-	return newX, newY, newZ
+	return []float32{newX, newY, newZ}
 }

--- a/server/internal/iteminternal/components.go
+++ b/server/internal/iteminternal/components.go
@@ -81,5 +81,43 @@ func Components(it world.CustomItem) map[string]any {
 	if x, ok := it.(item.HandEquipped); ok {
 		builder.AddProperty("hand_equipped", x.HandEquipped())
 	}
+
+	x, y, z := calculateHandPosition(it, float32(it.ImageSize()))
+
+	value := []float32{x, y, z}
+
+	builder.AddComponent("minecraft:render_offsets", map[string]any{
+		"main_hand": map[string]any{
+			"first_person": map[string]any{
+				"scale": value,
+			},
+			"third_person": map[string]any{
+				"scale": value,
+			},
+		},
+		"off_hand": map[string]any{
+			"first_person": map[string]any{
+				"scale": value,
+			},
+			"third_person": map[string]any{
+				"scale": value,
+			},
+		},
+	})
+
 	return builder.Construct()
+}
+
+// calculateHandPosition calculates the position of the item to be rendered to the player according to the given size.
+func calculateHandPosition(it world.CustomItem, size float32) (float32, float32, float32) {
+	var x, y, z float32
+	if _, ok := it.(item.HandEquipped); ok {
+		x, y, z = 0.075, 0.125, 0.075
+	} else {
+		x, y, z = 0.1, 0.1, 0.1
+	}
+	newX := x / (size / 16)
+	newY := y / (size / 16)
+	newZ := z / (size / 16)
+	return newX, newY, newZ
 }

--- a/server/internal/iteminternal/components.go
+++ b/server/internal/iteminternal/components.go
@@ -82,25 +82,27 @@ func Components(it world.CustomItem) map[string]any {
 		builder.AddProperty("hand_equipped", x.HandEquipped())
 	}
 
-	x, y, z := calculateItemScale(it, float32(it.ImageSize()))
+	bounds := it.Texture().Bounds()
 
-	value := []float32{x, y, z}
+	x, y, z := calculateItemScale(it, float32(bounds.Dx()), float32(bounds.Dy()))
+
+	itemScale := []float32{x, y, z}
 
 	builder.AddComponent("minecraft:render_offsets", map[string]any{
 		"main_hand": map[string]any{
 			"first_person": map[string]any{
-				"scale": value,
+				"scale": itemScale,
 			},
 			"third_person": map[string]any{
-				"scale": value,
+				"scale": itemScale,
 			},
 		},
 		"off_hand": map[string]any{
 			"first_person": map[string]any{
-				"scale": value,
+				"scale": itemScale,
 			},
 			"third_person": map[string]any{
-				"scale": value,
+				"scale": itemScale,
 			},
 		},
 	})
@@ -109,15 +111,13 @@ func Components(it world.CustomItem) map[string]any {
 }
 
 // calculateItemScale calculates the scale of the item to be rendered to the player according to the given size.
-func calculateItemScale(it world.CustomItem, size float32) (float32, float32, float32) {
-	var x, y, z float32
+func calculateItemScale(it world.CustomItem, width, height float32) (float32, float32, float32) {
+	var x, y, z float32 = 0.1, 0.1, 0.1
 	if _, ok := it.(item.HandEquipped); ok {
 		x, y, z = 0.075, 0.125, 0.075
-	} else {
-		x, y, z = 0.1, 0.1, 0.1
 	}
-	newX := x / (size / 16)
-	newY := y / (size / 16)
-	newZ := z / (size / 16)
+	newX := x / (width / 16)
+	newY := y / (height / 16)
+	newZ := z / (width / 16)
 	return newX, newY, newZ
 }

--- a/server/internal/iteminternal/components.go
+++ b/server/internal/iteminternal/components.go
@@ -82,7 +82,7 @@ func Components(it world.CustomItem) map[string]any {
 		builder.AddProperty("hand_equipped", x.HandEquipped())
 	}
 
-	x, y, z := calculateHandPosition(it, float32(it.ImageSize()))
+	x, y, z := calculateItemScale(it, float32(it.ImageSize()))
 
 	value := []float32{x, y, z}
 
@@ -108,8 +108,8 @@ func Components(it world.CustomItem) map[string]any {
 	return builder.Construct()
 }
 
-// calculateHandPosition calculates the scale of the item to be rendered to the player according to the given size.
-func calculateHandPosition(it world.CustomItem, size float32) (float32, float32, float32) {
+// calculateItemScale calculates the scale of the item to be rendered to the player according to the given size.
+func calculateItemScale(it world.CustomItem, size float32) (float32, float32, float32) {
 	var x, y, z float32
 	if _, ok := it.(item.HandEquipped); ok {
 		x, y, z = 0.075, 0.125, 0.075

--- a/server/world/item.go
+++ b/server/world/item.go
@@ -26,9 +26,6 @@ type CustomItem interface {
 	Texture() image.Image
 	// Category is the category the item will be listed under in the creative inventory.
 	Category() category.Category
-	// ImageSize is the width/height size value of the image which will be used to correct item render scale. We assume width and height are same.
-	// Minecraft uses 16x16 for their image. If your image uses 16x16 then you could return 16.
-	ImageSize() uint8
 }
 
 // RegisterItem registers an item with the ID and meta passed. Once registered, items may be obtained from an

--- a/server/world/item.go
+++ b/server/world/item.go
@@ -26,7 +26,7 @@ type CustomItem interface {
 	Texture() image.Image
 	// Category is the category the item will be listed under in the creative inventory.
 	Category() category.Category
-	// ImageSize is the width/height size value of the image which will be used to correct item render position. We assume width and height are same.
+	// ImageSize is the width/height size value of the image which will be used to correct item render scale. We assume width and height are same.
 	// Minecraft uses 16x16 for their image. If your image uses 16x16 then you could return 16.
 	ImageSize() uint8
 }

--- a/server/world/item.go
+++ b/server/world/item.go
@@ -26,6 +26,9 @@ type CustomItem interface {
 	Texture() image.Image
 	// Category is the category the item will be listed under in the creative inventory.
 	Category() category.Category
+	// ImageSize is the width/height size value of the image which will be used to correct item render position. We assume width and height are same.
+	// Minecraft uses 16x16 for their image. If your image uses 16x16 then you could return 16.
+	ImageSize() uint8
 }
 
 // RegisterItem registers an item with the ID and meta passed. Once registered, items may be obtained from an


### PR DESCRIPTION
With this PR you can correct the item scale. (It's more like modifying item render position. But there is a component which can set the position/rotation of custom item)

(Originally from my [CustomItemLoader](https://github.com/alvin0319/CustomItemLoader/blob/master/src/alvin0319/CustomItemLoader/item/properties/CustomItemProperties.php#L674-#L708) for PocketMine-MP)


The following images are showing the difference between non-render_offsets item and render_offsets item.

(This item has 32x32 width/height.)

Before this PR:
![Minecraft 2022-08-25 오후 10_55_08](https://user-images.githubusercontent.com/32565818/186685068-581461a5-6847-44dc-9778-7163621a845d.png)

After this PR:
![Minecraft 2022-08-25 오후 10_55_37](https://user-images.githubusercontent.com/32565818/186685077-cf147703-a239-452f-b042-15db84f5d723.png)

