### PR TITLE
Make the item.Stack argument in HandleItemPickup a pointer

### DIFF
--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -1,6 +1,9 @@
 package player
 
 import (
+	"net"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/cmd"
 	"github.com/df-mc/dragonfly/server/entity"
@@ -11,8 +14,6 @@ import (
 	"github.com/df-mc/dragonfly/server/player/skin"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"net"
-	"time"
 )
 
 // Handler handles events that are called by a player. Implementations of Handler may be used to listen to
@@ -117,7 +118,7 @@ type Handler interface {
 	HandleItemDamage(ctx *event.Context, i item.Stack, damage int)
 	// HandleItemPickup handles the player picking up an item from the ground. The item stack laying on the
 	// ground is passed. ctx.Cancel() may be called to prevent the player from picking up the item.
-	HandleItemPickup(ctx *event.Context, i item.Stack)
+	HandleItemPickup(ctx *event.Context, i *item.Stack)
 	// HandleItemDrop handles the player dropping an item on the ground. The dropped item entity is passed.
 	// ctx.Cancel() may be called to prevent the player from dropping the entity.Item passed on the ground.
 	// e.Item() may be called to obtain the item stack dropped.
@@ -157,7 +158,7 @@ func (NopHandler) HandleBlockBreak(*event.Context, cube.Pos, *[]item.Stack)     
 func (NopHandler) HandleBlockPlace(*event.Context, cube.Pos, world.Block)                     {}
 func (NopHandler) HandleBlockPick(*event.Context, cube.Pos, world.Block)                      {}
 func (NopHandler) HandleSignEdit(*event.Context, string, string)                              {}
-func (NopHandler) HandleItemPickup(*event.Context, item.Stack)                                {}
+func (NopHandler) HandleItemPickup(*event.Context, *item.Stack)                               {}
 func (NopHandler) HandleItemUse(*event.Context)                                               {}
 func (NopHandler) HandleItemUseOnBlock(*event.Context, cube.Pos, cube.Face, mgl64.Vec3)       {}
 func (NopHandler) HandleItemUseOnEntity(*event.Context, world.Entity)                         {}

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -1,9 +1,6 @@
 package player
 
 import (
-	"net"
-	"time"
-
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/cmd"
 	"github.com/df-mc/dragonfly/server/entity"
@@ -14,6 +11,8 @@ import (
 	"github.com/df-mc/dragonfly/server/player/skin"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
+	"net"
+	"time"
 )
 
 // Handler handles events that are called by a player. Implementations of Handler may be used to listen to

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2102,7 +2102,7 @@ func (p *Player) Collect(s item.Stack) int {
 		return 0
 	}
 	ctx := event.C()
-	if p.Handler().HandleItemPickup(ctx, s); ctx.Cancelled() {
+	if p.Handler().HandleItemPickup(ctx, &s); ctx.Cancelled() {
 		return 0
 	}
 	n, _ := p.Inventory().AddItem(s)


### PR DESCRIPTION
This can be useful for when you use your own items, with custom functionalities and want to have items drop on death and be picked up as they were before death. In my case, if the stack isn't replaced by my own custom soup implementation on pickup, then the soup is "broken", it would be a vanilla soup.