### PR TITLE
Update configuration interface so the Nop world provider can optionally be used

### DIFF
--- a/server/conf.go
+++ b/server/conf.go
@@ -187,6 +187,12 @@ type UserConfig struct {
 		QuitMessage string
 	}
 	World struct {
+		// SaveData controls whether a world's data will be saved and loaded.
+		// If true, the server will use the default LevelDB data provider and if
+		// false, an empty provider will be used. To use your own provider, turn
+		// this value to false as you will still be able to pass your own
+		// provider.
+		SaveData bool
 		// Folder is the folder that the data of the world resides in.
 		Folder string
 	}
@@ -239,9 +245,11 @@ func (uc UserConfig) Config(log Logger) (Config, error) {
 		ShutdownMessage:         uc.Server.ShutdownMessage,
 		DisableResourceBuilding: !uc.Resources.AutoBuildPack,
 	}
-	conf.WorldProvider, err = mcdb.New(log, uc.World.Folder, opt.FlateCompression)
-	if err != nil {
-		return conf, fmt.Errorf("create world provider: %w", err)
+	if uc.World.SaveData {
+		conf.WorldProvider, err = mcdb.New(log, uc.World.Folder, opt.FlateCompression)
+		if err != nil {
+			return conf, fmt.Errorf("create world provider: %w", err)
+		}
 	}
 	conf.Resources, err = loadResources(uc.Resources.Folder)
 	if err != nil {
@@ -297,6 +305,7 @@ func DefaultConfig() UserConfig {
 	c.Server.AuthEnabled = true
 	c.Server.JoinMessage = "%v has joined the game"
 	c.Server.QuitMessage = "%v has left the game"
+	c.World.SaveData = true
 	c.World.Folder = "world"
 	c.Players.MaximumChunkRadius = 32
 	c.Players.SaveData = true


### PR DESCRIPTION
When creating a `server.Config` from a `server.UserConfig` via `server.UserConfig.Config()`,  a persistent world provider (via `mcdb.New()`) is always created — there is no way to make use of `world.NopProvider` .

This PR addresses this lack by adding a new attribute `UserConfig.World.SaveData` , and updates `server.UserConfig.Config()` to honor it.

For consistency, this change matches the way `PlayerProvider` configuration is already implemented.