### PR TITLE
Silk touch for deepslate type

### DIFF
--- a/server/block/deepslate.go
+++ b/server/block/deepslate.go
@@ -20,11 +20,10 @@ type Deepslate struct {
 
 // BreakInfo ...
 func (d Deepslate) BreakInfo() BreakInfo {
-	hardness := 3.5
 	if d.Type == NormalDeepslate() {
-		hardness = 3
+		return newBreakInfo(3, pickaxeHarvestable, pickaxeEffective, silkTouchOneOf(Deepslate{Type: CobbledDeepslate()}, d)).withBlastResistance(18)
 	}
-	return newBreakInfo(hardness, pickaxeHarvestable, pickaxeEffective, oneOf(d)).withBlastResistance(18)
+	return newBreakInfo(3.5, pickaxeHarvestable, pickaxeEffective, oneOf(d)).withBlastResistance(18)
 }
 
 // SmeltInfo ...


### PR DESCRIPTION
Deepslate can only be obtained by mining it using a pickaxe with the Silk Touch enchantment, otherwise it drops cobbled deepslate.