### PR TITLE
Fix incorrect drops

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1884,7 +1884,7 @@ func (p *Player) drops(held item.Stack, b world.Block) []item.Stack {
 		drops = container.Inventory().Items()
 		if breakable, ok := b.(block.Breakable); ok && !p.GameMode().CreativeInventory() {
 			if breakable.BreakInfo().Harvestable(t) {
-				drops = breakable.BreakInfo().Drops(t, held.Enchantments())
+				drops = append(drops, breakable.BreakInfo().Drops(t, held.Enchantments())...)
 			}
 		}
 		container.Inventory().Clear()


### PR DESCRIPTION
In case you break the chest, all items in the chest that assigned to the drops variable got reassigned by drops of the current block.