### PR TITLE
Implement curse of binding

### DIFF
--- a/server/item/enchantment/curse_of_binding.go
+++ b/server/item/enchantment/curse_of_binding.go
@@ -25,7 +25,7 @@ func (CurseOfBinding) Cost(level int) (int, int) {
 
 // Rarity ...
 func (CurseOfBinding) Rarity() item.EnchantmentRarity {
-	return item.EnchantmentRarityCommon
+	return item.EnchantmentRarityVeryRare
 }
 
 // CompatibleWithEnchantment ...

--- a/server/item/enchantment/curse_of_binding.go
+++ b/server/item/enchantment/curse_of_binding.go
@@ -1,0 +1,41 @@
+package enchantment
+
+import (
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+// Curse of Binding is an enchantment that prevents removal of a cursed item from its armour slot.
+type CurseOfBinding struct{}
+
+// Name ...
+func (CurseOfBinding) Name() string {
+	return "Curse of Binding"
+}
+
+// MaxLevel ...
+func (CurseOfBinding) MaxLevel() int {
+	return 1
+}
+
+// Cost ...
+func (CurseOfBinding) Cost(level int) (int, int) {
+	return 0, 0
+}
+
+// Rarity ...
+func (CurseOfBinding) Rarity() item.EnchantmentRarity {
+	return item.EnchantmentRarityCommon
+}
+
+// CompatibleWithEnchantment ...
+func (CurseOfBinding) CompatibleWithEnchantment(item.EnchantmentType) bool {
+	return true
+}
+
+// CompatibleWithItem ...
+func (CurseOfBinding) CompatibleWithItem(i world.Item) bool {
+	_, isArmour := i.(item.Armour)
+
+	return isArmour
+}

--- a/server/item/enchantment/curse_of_binding.go
+++ b/server/item/enchantment/curse_of_binding.go
@@ -39,3 +39,13 @@ func (CurseOfBinding) CompatibleWithItem(i world.Item) bool {
 
 	return isArmour
 }
+
+// Treasure ...
+func (CurseOfBinding) Treasure() bool {
+    return true
+}
+
+// Curse ...
+func (CurseOfBinding) Curse() bool {
+    return true
+}

--- a/server/item/enchantment/register.go
+++ b/server/item/enchantment/register.go
@@ -30,7 +30,7 @@ func init() {
 	// TODO: (24) Lure.
 	// TODO: (25) Frost Walker.
 	item.RegisterEnchantment(26, Mending{})
-	// TODO: (27) Curse of Binding.
+	item.RegisterEnchantment(27, CurseOfBinding{})
 	item.RegisterEnchantment(28, CurseOfVanishing{})
 	// TODO: (29) Impaling.
 	// TODO: (30) Riptide.

--- a/server/session/handler_item_stack_request.go
+++ b/server/session/handler_item_stack_request.go
@@ -160,7 +160,8 @@ func (h *ItemStackRequestHandler) handleTransfer(from, to protocol.StackRequestS
 	}
 
 	// Do not allow an equipped item cursed with binding to be transferred.
-	if from.ContainerID == protocol.ContainerArmor {
+    creativeMode := s.c.GameMode().CreativeInventory()
+	if from.ContainerID == protocol.ContainerArmor && !creativeMode {
 		i, _ := h.itemInSlot(from, s)
 		if _, isCursed := i.Enchantment(enchantment.CurseOfBinding{}); isCursed {
 			return nil
@@ -208,7 +209,8 @@ func (h *ItemStackRequestHandler) handleSwap(a *protocol.SwapStackRequestAction,
 	}
 
 	// Do not allow an equipped item cursed with binding to be swapped out.
-	if a.Destination.ContainerID == protocol.ContainerArmor {
+    creativeMode := s.c.GameMode().CreativeInventory()
+	if a.Destination.ContainerID == protocol.ContainerArmor && !creativeMode {
 		i, _ := h.itemInSlot(a.Destination, s)
 		if _, isCursed := i.Enchantment(enchantment.CurseOfBinding{}); isCursed {
 			return nil
@@ -273,7 +275,8 @@ func (h *ItemStackRequestHandler) handleDrop(a *protocol.DropStackRequestAction,
 	}
 
 	// Do not allow an equipped item cursed with binding to be dropped.
-	if a.Source.ContainerID == protocol.ContainerArmor {
+    creativeMode := s.c.GameMode().CreativeInventory()
+	if a.Source.ContainerID == protocol.ContainerArmor && !creativeMode {
 		i, _ := h.itemInSlot(a.Source, s)
 		if _, isCursed := i.Enchantment(enchantment.CurseOfBinding{}); isCursed {
 			return nil


### PR DESCRIPTION
This PR implements the curse of binding enchantment.

- Items that implement the item.Armour interface can be enchanted with the curse of binding
- Items with the curse of binding equipped in the armour inventory cannot be removed by inventory interaction
- Items with the curse of binding cannot have the enchantment removed through the use of a grindstone
- The cost has been set at 0 because this enchantment is not obtainable through an enchanting table