### PR TITLE
Limit transactions size

### DIFF
--- a/server/session/handler_inventory_transaction.go
+++ b/server/session/handler_inventory_transaction.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/event"
@@ -58,6 +59,11 @@ func (h *InventoryTransactionHandler) resendInventories(s *Session) {
 
 // handleNormalTransaction ...
 func (h *InventoryTransactionHandler) handleNormalTransaction(pk *packet.InventoryTransaction, s *Session) error {
+	if len(pk.Actions) > 100 {
+		s.Disconnect("Too many actions in item use transaction")
+		return errors.New("too many actions in item use transaction")
+	}
+
 	for _, action := range pk.Actions {
 		switch action.SourceType {
 		case protocol.InventoryActionSourceWorld:

--- a/server/session/handler_player_auth_input.go
+++ b/server/session/handler_player_auth_input.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"errors"
 	"fmt"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/go-gl/mathgl/mgl32"
@@ -126,6 +127,11 @@ func (h PlayerAuthInputHandler) handleInputFlags(flags uint64, s *Session) {
 
 // handleUseItemData handles the protocol.UseItemTransactionData found in a packet.PlayerAuthInput.
 func (h PlayerAuthInputHandler) handleUseItemData(data protocol.UseItemTransactionData, s *Session) error {
+	if len(data.Actions) > 100 {
+		s.Disconnect("Too many actions in item use transaction")
+		return errors.New("too many actions in item use transaction")
+	}
+
 	s.swingingArm.Store(true)
 	defer s.swingingArm.Store(false)
 
@@ -148,6 +154,11 @@ func (h PlayerAuthInputHandler) handleUseItemData(data protocol.UseItemTransacti
 
 // handleBlockActions handles a slice of protocol.PlayerBlockAction present in a PlayerAuthInput packet.
 func (h PlayerAuthInputHandler) handleBlockActions(a []protocol.PlayerBlockAction, s *Session) error {
+	if len(a) > 100 {
+		s.Disconnect("Too many block actions")
+		return errors.New("too many block actions in PlayerAuthInput packet")
+	}
+
 	for _, action := range a {
 		if err := handlePlayerAction(action.Action, action.Face, action.BlockPos, selfEntityRuntimeID, s); err != nil {
 			return err


### PR DESCRIPTION
# Summary

This pull request fixes a bug where inventory transactions were being processed incorrectly when the quantity of inventory actions was too large.

# Details

When the quantity of actions in an inventory transaction exceeded a certain value, the server was freezing.

This pull request fixes the issue by adding a check to ensure that the quantity of actions does not exceed the maximum allowed value before processing the transaction.

# Impacted Areas in Application

- Inventory transactions