### PR TITLE
Implement event structs

### DIFF
--- a/server/block/fire.go
+++ b/server/block/fire.go
@@ -184,12 +184,27 @@ func (f Fire) tick(pos cube.Pos, w *world.World, r *rand.Rand) {
 func (f Fire) spread(from, to cube.Pos, w *world.World, r *rand.Rand) {
 	if _, air := w.Block(to).(Air); !air {
 		ctx := event.C()
-		if w.Handler().HandleBlockBurn(ctx, to); ctx.Cancelled() {
+
+		evt := world.EventBlockBurn{
+			w,
+			to,
+			ctx,
+		}
+
+		if w.Handler().HandleBlockBurn(evt); evt.Cancelled() {
 			return
 		}
 	}
 	ctx := event.C()
-	if w.Handler().HandleFireSpread(ctx, from, to); ctx.Cancelled() {
+
+	evt := world.EventFireSpread{
+		w,
+		from,
+		to,
+		ctx,
+	}
+
+	if w.Handler().HandleFireSpread(evt); evt.Cancelled() {
 		return
 	}
 	w.SetBlock(to, Fire{Type: f.Type, Age: min(15, f.Age+r.Intn(5)/4)}, nil)

--- a/server/block/lava.go
+++ b/server/block/lava.go
@@ -163,7 +163,17 @@ func (l Lava) Harden(pos cube.Pos, w *world.World, flownIntoBy *cube.Pos) bool {
 		}, w.Range())
 		if b != nil {
 			ctx := event.C()
-			if w.Handler().HandleLiquidHarden(ctx, pos, l, water, b); ctx.Cancelled() {
+
+			evt := world.EventLiquidHarden{
+				w,
+				pos,
+				l,
+				water,
+				b,
+				ctx,
+			}
+
+			if w.Handler().HandleLiquidHarden(evt); evt.Cancelled() {
 				return false
 			}
 			w.PlaySound(pos.Vec3Centre(), sound.Fizz{})
@@ -183,7 +193,17 @@ func (l Lava) Harden(pos cube.Pos, w *world.World, flownIntoBy *cube.Pos) bool {
 		b = Cobblestone{}
 	}
 	ctx := event.C()
-	if w.Handler().HandleLiquidHarden(ctx, pos, l, water, b); ctx.Cancelled() {
+
+	evt := world.EventLiquidHarden{
+		w,
+		pos,
+		l,
+		water,
+		b,
+		ctx,
+	}
+
+	if w.Handler().HandleLiquidHarden(evt); evt.Cancelled() {
 		return false
 	}
 	w.SetBlock(pos, b, nil)

--- a/server/block/liquid.go
+++ b/server/block/liquid.go
@@ -43,7 +43,16 @@ func tickLiquid(b world.Liquid, pos cube.Pos, w *world.World) {
 			res = b.WithDepth(b.LiquidDepth()-2*b.SpreadDecay(), false)
 		}
 		ctx := event.C()
-		if w.Handler().HandleLiquidDecay(ctx, pos, b, res); ctx.Cancelled() {
+
+		evt := world.EventLiquidDecay{
+			w,
+			pos,
+			b,
+			res,
+			ctx,
+		}
+
+		if w.Handler().HandleLiquidDecay(evt); evt.Cancelled() {
 			return
 		}
 		w.SetLiquid(pos, res)
@@ -139,7 +148,17 @@ func flowInto(b world.Liquid, src, pos cube.Pos, w *world.World, falling bool) b
 			return true
 		}
 		ctx := event.C()
-		if w.Handler().HandleLiquidFlow(ctx, src, pos, b.WithDepth(newDepth, falling), existing); ctx.Cancelled() {
+
+		evt := world.EventLiquidFlow{
+			w,
+			src,
+			pos,
+			b.WithDepth(newDepth, falling),
+			existing,
+			ctx,
+		}
+
+		if w.Handler().HandleLiquidFlow(evt); evt.Cancelled() {
 			return false
 		}
 		w.SetLiquid(pos, b.WithDepth(newDepth, falling))
@@ -161,7 +180,17 @@ func flowInto(b world.Liquid, src, pos cube.Pos, w *world.World, falling bool) b
 		return false
 	}
 	ctx := event.C()
-	if w.Handler().HandleLiquidFlow(ctx, src, pos, b.WithDepth(newDepth, falling), existing); ctx.Cancelled() {
+
+	evt := world.EventLiquidFlow{
+		w,
+		src,
+		pos,
+		b.WithDepth(newDepth, falling),
+		existing,
+		ctx,
+	}
+
+	if w.Handler().HandleLiquidFlow(evt); evt.Cancelled() {
 		return false
 	}
 

--- a/server/block/water.go
+++ b/server/block/water.go
@@ -102,7 +102,17 @@ func (w Water) ScheduledTick(pos cube.Pos, wo *world.World, _ *rand.Rand) {
 				// below this is not falling (full source block).
 				res := Water{Depth: 8, Still: true}
 				ctx := event.C()
-				if wo.Handler().HandleLiquidFlow(ctx, pos, pos, res, w); ctx.Cancelled() {
+
+				evt := world.EventLiquidFlow{
+					wo,
+					pos,
+					pos,
+					res,
+					w,
+					ctx,
+				}
+
+				if wo.Handler().HandleLiquidFlow(evt); evt.Cancelled() {
 					return
 				}
 				wo.SetLiquid(pos, res)
@@ -134,7 +144,17 @@ func (w Water) Harden(pos cube.Pos, wo *world.World, flownIntoBy *cube.Pos) bool
 	}
 	if lava, ok := wo.Block(pos.Side(cube.FaceUp)).(Lava); ok {
 		ctx := event.C()
-		if wo.Handler().HandleLiquidHarden(ctx, pos, w, lava, Stone{}); ctx.Cancelled() {
+
+		evt := world.EventLiquidHarden{
+			wo,
+			pos,
+			w,
+			lava,
+			Stone{},
+			ctx,
+		}
+
+		if wo.Handler().HandleLiquidHarden(evt); evt.Cancelled() {
 			return false
 		}
 		wo.SetBlock(pos, Stone{}, nil)
@@ -142,7 +162,17 @@ func (w Water) Harden(pos cube.Pos, wo *world.World, flownIntoBy *cube.Pos) bool
 		return true
 	} else if lava, ok := wo.Block(*flownIntoBy).(Lava); ok {
 		ctx := event.C()
-		if wo.Handler().HandleLiquidHarden(ctx, pos, w, lava, Cobblestone{}); ctx.Cancelled() {
+
+		evt := world.EventLiquidHarden{
+			wo,
+			pos,
+			w,
+			lava,
+			Cobblestone{},
+			ctx,
+		}
+
+		if wo.Handler().HandleLiquidHarden(evt); evt.Cancelled() {
 			return false
 		}
 		wo.SetBlock(*flownIntoBy, Cobblestone{}, nil)

--- a/server/item/inventory/events.go
+++ b/server/item/inventory/events.go
@@ -1,0 +1,27 @@
+package inventory
+
+import (
+	"github.com/df-mc/dragonfly/server/event"
+	"github.com/df-mc/dragonfly/server/item"
+)
+
+type EventDrop struct {
+	Inventory *Inventory
+	Slot      int
+	ItemStack item.Stack
+	*event.Context
+}
+
+type EventPlace struct {
+	Inventory *Inventory
+	Slot      int
+	ItemStack item.Stack
+	*event.Context
+}
+
+type EventTake struct {
+	Inventory *Inventory
+	Slot      int
+	ItemStack item.Stack
+	*event.Context
+}

--- a/server/item/inventory/handler.go
+++ b/server/item/inventory/handler.go
@@ -1,20 +1,15 @@
 package inventory
 
-import (
-	"github.com/df-mc/dragonfly/server/event"
-	"github.com/df-mc/dragonfly/server/item"
-)
-
 // Handler is a type that may be used to handle actions performed on an inventory by a player.
 type Handler interface {
 	// HandleTake handles an item.Stack being taken from a slot in the inventory. This item might be the whole stack or
 	// part of the stack currently present in that slot.
-	HandleTake(ctx *event.Context, slot int, it item.Stack)
+	HandleTake(EventTake)
 	// HandlePlace handles an item.Stack being placed in a slot of the inventory. It might either be added to an empty
 	// slot or a slot that contains an item of the same type.
-	HandlePlace(ctx *event.Context, slot int, it item.Stack)
+	HandlePlace(EventPlace)
 	// HandleDrop handles the dropping of an item.Stack in a slot out of the inventory.
-	HandleDrop(ctx *event.Context, slot int, it item.Stack)
+	HandleDrop(EventDrop)
 }
 
 // Check to make sure NopHandler implements Handler.
@@ -24,6 +19,6 @@ var _ Handler = NopHandler{}
 // Handler of an Inventory.
 type NopHandler struct{}
 
-func (NopHandler) HandleTake(*event.Context, int, item.Stack)  {}
-func (NopHandler) HandlePlace(*event.Context, int, item.Stack) {}
-func (NopHandler) HandleDrop(*event.Context, int, item.Stack)  {}
+func (NopHandler) HandleTake(EventTake)  {}
+func (NopHandler) HandlePlace(EventPlace) {}
+func (NopHandler) HandleDrop(EventDrop)  {}

--- a/server/item/inventory/handler.go
+++ b/server/item/inventory/handler.go
@@ -19,6 +19,6 @@ var _ Handler = NopHandler{}
 // Handler of an Inventory.
 type NopHandler struct{}
 
-func (NopHandler) HandleTake(EventTake)  {}
+func (NopHandler) HandleTake(EventTake)   {}
 func (NopHandler) HandlePlace(EventPlace) {}
-func (NopHandler) HandleDrop(EventDrop)  {}
+func (NopHandler) HandleDrop(EventDrop)   {}

--- a/server/item/inventory/inventory.go
+++ b/server/item/inventory/inventory.go
@@ -16,8 +16,8 @@ import (
 // an inventory is invalid. Use New() to obtain a new inventory.
 // Inventory is safe for concurrent usage: Its values are protected by a mutex.
 type Inventory struct {
-	mu    sync.RWMutex
-	h     Handler
+	mu sync.RWMutex
+    handler Handler
 	slots []item.Stack
 
 	f      func(slot int, before, after item.Stack)
@@ -39,7 +39,7 @@ func New(size int, f func(slot int, before, after item.Stack)) *Inventory {
 	if f == nil {
 		f = func(slot int, before, after item.Stack) {}
 	}
-	return &Inventory{h: NopHandler{}, slots: make([]item.Stack, size), f: f, canAdd: func(s item.Stack, slot int) bool { return true }}
+    return &Inventory{handler: NopHandler{}, slots: make([]item.Stack, size), f: f, canAdd: func(s item.Stack, slot int) bool { return true }}
 }
 
 // Item attempts to obtain an item from a specific slot in the inventory. If an item was present in that slot,
@@ -302,7 +302,7 @@ func (inv *Inventory) Handle(h Handler) {
 	if h == nil {
 		h = NopHandler{}
 	}
-	inv.h = h
+	inv.handler = h
 }
 
 // Handler returns the Handler currently assigned to the Inventory. This is the NopHandler by default.
@@ -311,7 +311,7 @@ func (inv *Inventory) Handler() Handler {
 	defer inv.mu.RUnlock()
 
 	inv.check()
-	return inv.h
+	return inv.handler
 }
 
 // setItem sets an item to a specific slot and overwrites the existing item. It calls the function which is

--- a/server/item/inventory/inventory.go
+++ b/server/item/inventory/inventory.go
@@ -16,9 +16,9 @@ import (
 // an inventory is invalid. Use New() to obtain a new inventory.
 // Inventory is safe for concurrent usage: Its values are protected by a mutex.
 type Inventory struct {
-	mu sync.RWMutex
-    handler Handler
-	slots []item.Stack
+	mu      sync.RWMutex
+	handler Handler
+	slots   []item.Stack
 
 	f      func(slot int, before, after item.Stack)
 	canAdd func(s item.Stack, slot int) bool
@@ -39,7 +39,7 @@ func New(size int, f func(slot int, before, after item.Stack)) *Inventory {
 	if f == nil {
 		f = func(slot int, before, after item.Stack) {}
 	}
-    return &Inventory{handler: NopHandler{}, slots: make([]item.Stack, size), f: f, canAdd: func(s item.Stack, slot int) bool { return true }}
+	return &Inventory{handler: NopHandler{}, slots: make([]item.Stack, size), f: f, canAdd: func(s item.Stack, slot int) bool { return true }}
 }
 
 // Item attempts to obtain an item from a specific slot in the inventory. If an item was present in that slot,

--- a/server/player/events.go
+++ b/server/player/events.go
@@ -47,8 +47,8 @@ type EventBlockPlace struct {
 
 type EventChangeWorld struct {
 	Player *Player
-	From *world.World
-	To  *world.World
+	From   *world.World
+	To     *world.World
 }
 
 type EventChat struct {

--- a/server/player/events.go
+++ b/server/player/events.go
@@ -47,13 +47,12 @@ type EventBlockPlace struct {
 
 type EventChangeWorld struct {
 	Player *Player
-	Before *world.World
-	After  *world.World
+	From *world.World
+	To  *world.World
 }
 
 type EventChat struct {
 	Player  *Player
-	Prefix  *string
 	Message *string
 	*event.Context
 }

--- a/server/player/events.go
+++ b/server/player/events.go
@@ -1,0 +1,214 @@
+package player
+
+import (
+	"github.com/df-mc/dragonfly/server/block"
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/cmd"
+	"github.com/df-mc/dragonfly/server/entity"
+	"github.com/df-mc/dragonfly/server/event"
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/player/skin"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/go-gl/mathgl/mgl64"
+	"net"
+	"time"
+)
+
+type EventAttackEntity struct {
+	Player   *Player
+	Entity   world.Entity
+	Force    *float64
+	Height   *float64
+	Critical *bool
+	*event.Context
+}
+
+type EventBlockBreak struct {
+	Player     *Player
+	Position   cube.Pos
+	Drops      *[]item.Stack
+	Experience *int
+	*event.Context
+}
+
+type EventBlockPick struct {
+	Player   *Player
+	Position cube.Pos
+	Block    world.Block
+	*event.Context
+}
+
+type EventBlockPlace struct {
+	Player   *Player
+	Position cube.Pos
+	Block    world.Block
+	*event.Context
+}
+
+type EventChangeWorld struct {
+	Player *Player
+	Before *world.World
+	After  *world.World
+}
+
+type EventChat struct {
+	Player  *Player
+	Prefix  *string
+	Message *string
+	*event.Context
+}
+
+type EventCommandExecution struct {
+	Player    *Player
+	Command   cmd.Command
+	Arguments []string
+	*event.Context
+}
+
+type EventDeath struct {
+	Player        *Player
+	Source        world.DamageSource
+	KeepInventory *bool
+}
+
+type EventExperienceGain struct {
+	Player *Player
+	Amount *int
+	*event.Context
+}
+
+type EventFoodLoss struct {
+	Player *Player
+	From   int
+	To     *int
+	*event.Context
+}
+
+type EventHeal struct {
+	Player *Player
+	Amount *float64
+	Source world.HealingSource
+	*event.Context
+}
+
+type EventHurt struct {
+	Player         *Player
+	Damage         *float64
+	AttackImmunity *time.Duration
+	Source         world.DamageSource
+	*event.Context
+}
+
+type EventItemConsume struct {
+	Player    *Player
+	ItemStack item.Stack
+	*event.Context
+}
+
+type EventItemDamage struct {
+	Player    *Player
+	ItemStack item.Stack
+	Damage    int
+	*event.Context
+}
+
+type EventItemDrop struct {
+	Player *Player
+	Item   *entity.Item
+	*event.Context
+}
+
+type EventItemPickup struct {
+	Player    *Player
+	ItemStack item.Stack
+	*event.Context
+}
+
+type EventItemUse struct {
+	Player *Player
+	*event.Context
+}
+
+type EventItemUseOnBlock struct {
+	Player        *Player
+	Position      cube.Pos
+	Face          cube.Face
+	ClickPosition mgl64.Vec3
+	*event.Context
+}
+
+type EventItemUseOnEntity struct {
+	Player *Player
+	Entity world.Entity
+	*event.Context
+}
+
+type EventJump struct {
+	Player *Player
+}
+
+type EventMove struct {
+	Player      *Player
+	NewPosition mgl64.Vec3
+	NewYaw      float64
+	NewPitch    float64
+	*event.Context
+}
+
+type EventPunchAir struct {
+	Player *Player
+	*event.Context
+}
+
+type EventQuit struct {
+	Player *Player
+}
+
+type EventRespawn struct {
+	Player   *Player
+	Position *mgl64.Vec3
+	World    **world.World
+}
+
+type EventSignEdit struct {
+	Player  *Player
+	Sign    block.Sign
+	NewText *string
+	*event.Context
+}
+
+type EventSkinChange struct {
+	Player *Player
+	Skin   *skin.Skin
+	*event.Context
+}
+
+type EventStartBreak struct {
+	Player   *Player
+	Position cube.Pos
+	*event.Context
+}
+
+type EventTeleport struct {
+	Player      *Player
+	NewPosition mgl64.Vec3
+	*event.Context
+}
+
+type EventToggleSneak struct {
+	Player     *Player
+	IsSneaking bool
+	*event.Context
+}
+
+type EventToggleSprint struct {
+	Player      *Player
+	IsSprinting bool
+	*event.Context
+}
+
+type EventTransfer struct {
+	Player  *Player
+	Address *net.UDPAddr
+	*event.Context
+}

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -18,75 +18,75 @@ import (
 type Handler interface {
 	// HandleMove handles the movement of a player. ctx.Cancel() may be called to cancel the movement event.
 	// The new position, yaw and pitch are passed.
-	HandleMove(ctx *event.Context, newPos mgl64.Vec3, newYaw, newPitch float64)
+	HandleMove(EventMove)
 	// HandleJump handles the player jumping.
-	HandleJump()
+	HandleJump(EventJump)
 	// HandleTeleport handles the teleportation of a player. ctx.Cancel() may be called to cancel it.
-	HandleTeleport(ctx *event.Context, pos mgl64.Vec3)
+	HandleTeleport(EventTeleport)
 	// HandleChangeWorld handles when the player is added to a new world. before may be nil.
-	HandleChangeWorld(before, after *world.World)
+	HandleChangeWorld(EventChangeWorld)
 	// HandleToggleSprint handles when the player starts or stops sprinting.
 	// After is true if the player is sprinting after toggling (changing their sprinting state).
-	HandleToggleSprint(ctx *event.Context, after bool)
+	HandleToggleSprint(EventToggleSprint)
 	// HandleToggleSneak handles when the player starts or stops sneaking.
 	// After is true if the player is sneaking after toggling (changing their sneaking state).
-	HandleToggleSneak(ctx *event.Context, after bool)
+	HandleToggleSneak(EventToggleSneak)
 	// HandleChat handles a message sent in the chat by a player. ctx.Cancel() may be called to cancel the
 	// message being sent in chat.
 	// The message may be changed by assigning to *message.
-	HandleChat(ctx *event.Context, message *string)
+	HandleChat(EventChat)
 	// HandleFoodLoss handles the food bar of a player depleting naturally, for example because the player was
 	// sprinting and jumping. ctx.Cancel() may be called to cancel the food points being lost.
-	HandleFoodLoss(ctx *event.Context, from int, to *int)
+	HandleFoodLoss(EventFoodLoss)
 	// HandleHeal handles the player being healed by a healing source. ctx.Cancel() may be called to cancel
 	// the healing.
 	// The health added may be changed by assigning to *health.
-	HandleHeal(ctx *event.Context, health *float64, src world.HealingSource)
+	HandleHeal(EventHeal)
 	// HandleHurt handles the player being hurt by any damage source. ctx.Cancel() may be called to cancel the
 	// damage being dealt to the player.
 	// The damage dealt to the player may be changed by assigning to *damage.
-	HandleHurt(ctx *event.Context, damage *float64, attackImmunity *time.Duration, src world.DamageSource)
+	HandleHurt(EventHurt)
 	// HandleDeath handles the player dying to a particular damage cause.
-	HandleDeath(src world.DamageSource, keepInv *bool)
+	HandleDeath(EventDeath)
 	// HandleRespawn handles the respawning of the player in the world. The spawn position passed may be
 	// changed by assigning to *pos. The world.World in which the Player is respawned may be modifying by assigning to
 	// *w. This world may be the world the Player died in, but it might also point to a different world (the overworld)
 	// if the Player died in the nether or end.
-	HandleRespawn(pos *mgl64.Vec3, w **world.World)
+	HandleRespawn(EventRespawn)
 	// HandleSkinChange handles the player changing their skin. ctx.Cancel() may be called to cancel the skin
 	// change.
-	HandleSkinChange(ctx *event.Context, skin *skin.Skin)
+	HandleSkinChange(EventSkinChange)
 	// HandleStartBreak handles the player starting to break a block at the position passed. ctx.Cancel() may
 	// be called to stop the player from breaking the block completely.
-	HandleStartBreak(ctx *event.Context, pos cube.Pos)
+	HandleStartBreak(EventStartBreak)
 	// HandleBlockBreak handles a block that is being broken by a player. ctx.Cancel() may be called to cancel
 	// the block being broken. A pointer to a slice of the block's drops is passed, and may be altered
 	// to change what items will actually be dropped.
-	HandleBlockBreak(ctx *event.Context, pos cube.Pos, drops *[]item.Stack, xp *int)
+	HandleBlockBreak(EventBlockBreak)
 	// HandleBlockPlace handles the player placing a specific block at a position in its world. ctx.Cancel()
 	// may be called to cancel the block being placed.
-	HandleBlockPlace(ctx *event.Context, pos cube.Pos, b world.Block)
+	HandleBlockPlace(EventBlockPlace)
 	// HandleBlockPick handles the player picking a specific block at a position in its world. ctx.Cancel()
 	// may be called to cancel the block being picked.
-	HandleBlockPick(ctx *event.Context, pos cube.Pos, b world.Block)
+	HandleBlockPick(EventBlockPick)
 	// HandleItemUse handles the player using an item in the air. It is called for each item, although most
 	// will not actually do anything. Items such as snowballs may be thrown if HandleItemUse does not cancel
 	// the context using ctx.Cancel(). It is not called if the player is holding no item.
-	HandleItemUse(ctx *event.Context)
+	HandleItemUse(EventItemUse)
 	// HandleItemUseOnBlock handles the player using the item held in its main hand on a block at the block
 	// position passed. The face of the block clicked is also passed, along with the relative click position.
 	// The click position has X, Y and Z values which are all in the range 0.0-1.0. It is also called if the
 	// player is holding no item.
-	HandleItemUseOnBlock(ctx *event.Context, pos cube.Pos, face cube.Face, clickPos mgl64.Vec3)
+	HandleItemUseOnBlock(EventItemUseOnBlock)
 	// HandleItemUseOnEntity handles the player using the item held in its main hand on an entity passed to
 	// the method.
 	// HandleItemUseOnEntity is always called when a player uses an item on an entity, regardless of whether
 	// the item actually does anything when used on an entity. It is also called if the player is holding no
 	// item.
-	HandleItemUseOnEntity(ctx *event.Context, e world.Entity)
+	HandleItemUseOnEntity(EventItemUseOnEntity)
 	// HandleItemConsume handles the player consuming an item. This is called whenever a consumable such as
 	// food is consumed.
-	HandleItemConsume(ctx *event.Context, item item.Stack)
+	HandleItemConsume(EventItemConsume)
 	// HandleAttackEntity handles the player attacking an entity using the item held in its hand. ctx.Cancel()
 	// may be called to cancel the attack, which will cancel damage dealt to the target and will stop the
 	// entity from being knocked back.
@@ -98,37 +98,37 @@ type Handler interface {
 	// The attack can be a critical attack, which would increase damage by a factor of 1.5 and
 	// spawn critical hit particles around the target entity. These particles will not be displayed
 	// if no damage is dealt.
-	HandleAttackEntity(ctx *event.Context, e world.Entity, force, height *float64, critical *bool)
+	HandleAttackEntity(EventAttackEntity)
 	// HandleExperienceGain handles the player gaining experience. ctx.Cancel() may be called to cancel
 	// the gain.
 	// The amount is also provided which can be modified.
-	HandleExperienceGain(ctx *event.Context, amount *int)
+	HandleExperienceGain(EventExperienceGain)
 	// HandlePunchAir handles the player punching air.
-	HandlePunchAir(ctx *event.Context)
+	HandlePunchAir(EventPunchAir)
 	// HandleSignEdit handles the player editing a sign. It is called for every keystroke while editing a sign and
 	// has both the old text passed and the text after the edit. This typically only has a change of one character.
-	HandleSignEdit(ctx *event.Context, oldText, newText string)
+	HandleSignEdit(EventSignEdit)
 	// HandleItemDamage handles the event wherein the item either held by the player or as armour takes
 	// damage through usage.
 	// The type of the item may be checked to determine whether it was armour or a tool used. The damage to
 	// the item is passed.
-	HandleItemDamage(ctx *event.Context, i item.Stack, damage int)
+	HandleItemDamage(EventItemDamage)
 	// HandleItemPickup handles the player picking up an item from the ground. The item stack laying on the
 	// ground is passed. ctx.Cancel() may be called to prevent the player from picking up the item.
-	HandleItemPickup(ctx *event.Context, i item.Stack)
+	HandleItemPickup(EventItemPickup)
 	// HandleItemDrop handles the player dropping an item on the ground. The dropped item entity is passed.
 	// ctx.Cancel() may be called to prevent the player from dropping the entity.Item passed on the ground.
 	// e.Item() may be called to obtain the item stack dropped.
-	HandleItemDrop(ctx *event.Context, e *entity.Item)
+	HandleItemDrop(EventItemDrop)
 	// HandleTransfer handles a player being transferred to another server. ctx.Cancel() may be called to
 	// cancel the transfer.
-	HandleTransfer(ctx *event.Context, addr *net.UDPAddr)
+	HandleTransfer(EventTransfer)
 	// HandleCommandExecution handles the command execution of a player, who wrote a command in the chat.
 	// ctx.Cancel() may be called to cancel the command execution.
-	HandleCommandExecution(ctx *event.Context, command cmd.Command, args []string)
+	HandleCommandExecution(EventCommandExecution)
 	// HandleQuit handles the closing of a player. It is always called when the player is disconnected,
 	// regardless of the reason.
-	HandleQuit()
+	HandleQuit(EventQuit)
 }
 
 // NopHandler implements the Handler interface but does not execute any code when an event is called. The
@@ -139,34 +139,34 @@ type NopHandler struct{}
 // Compile time check to make sure NopHandler implements Handler.
 var _ Handler = NopHandler{}
 
-func (NopHandler) HandleItemDrop(*event.Context, *entity.Item)                                {}
-func (NopHandler) HandleMove(*event.Context, mgl64.Vec3, float64, float64)                    {}
-func (NopHandler) HandleJump()                                                                {}
-func (NopHandler) HandleTeleport(*event.Context, mgl64.Vec3)                                  {}
-func (NopHandler) HandleChangeWorld(*world.World, *world.World)                               {}
-func (NopHandler) HandleToggleSprint(*event.Context, bool)                                    {}
-func (NopHandler) HandleToggleSneak(*event.Context, bool)                                     {}
-func (NopHandler) HandleCommandExecution(*event.Context, cmd.Command, []string)               {}
-func (NopHandler) HandleTransfer(*event.Context, *net.UDPAddr)                                {}
-func (NopHandler) HandleChat(*event.Context, *string)                                         {}
-func (NopHandler) HandleSkinChange(*event.Context, *skin.Skin)                                {}
-func (NopHandler) HandleStartBreak(*event.Context, cube.Pos)                                  {}
-func (NopHandler) HandleBlockBreak(*event.Context, cube.Pos, *[]item.Stack, *int)             {}
-func (NopHandler) HandleBlockPlace(*event.Context, cube.Pos, world.Block)                     {}
-func (NopHandler) HandleBlockPick(*event.Context, cube.Pos, world.Block)                      {}
-func (NopHandler) HandleSignEdit(*event.Context, string, string)                              {}
-func (NopHandler) HandleItemPickup(*event.Context, item.Stack)                                {}
-func (NopHandler) HandleItemUse(*event.Context)                                               {}
-func (NopHandler) HandleItemUseOnBlock(*event.Context, cube.Pos, cube.Face, mgl64.Vec3)       {}
-func (NopHandler) HandleItemUseOnEntity(*event.Context, world.Entity)                         {}
-func (NopHandler) HandleItemConsume(*event.Context, item.Stack)                               {}
-func (NopHandler) HandleItemDamage(*event.Context, item.Stack, int)                           {}
-func (NopHandler) HandleAttackEntity(*event.Context, world.Entity, *float64, *float64, *bool) {}
-func (NopHandler) HandleExperienceGain(*event.Context, *int)                                  {}
-func (NopHandler) HandlePunchAir(*event.Context)                                              {}
-func (NopHandler) HandleHurt(*event.Context, *float64, *time.Duration, world.DamageSource)    {}
-func (NopHandler) HandleHeal(*event.Context, *float64, world.HealingSource)                   {}
-func (NopHandler) HandleFoodLoss(*event.Context, int, *int)                                   {}
-func (NopHandler) HandleDeath(world.DamageSource, *bool)                                      {}
-func (NopHandler) HandleRespawn(*mgl64.Vec3, **world.World)                                   {}
-func (NopHandler) HandleQuit()                                                                {}
+func (NopHandler) HandleAttackEntity(EventAttackEntity)         {}
+func (NopHandler) HandleBlockBreak(EventBlockBreak)             {}
+func (NopHandler) HandleBlockPick(EventBlockPick)               {}
+func (NopHandler) HandleBlockPlace(EventBlockPlace)             {}
+func (NopHandler) HandleChangeWorld(EventChangeWorld)           {}
+func (NopHandler) HandleChat(EventChat)                         {}
+func (NopHandler) HandleCommandExecution(EventCommandExecution) {}
+func (NopHandler) HandleDeath(EventDeath)                       {}
+func (NopHandler) HandleExperienceGain(EventExperienceGain)     {}
+func (NopHandler) HandleFoodLoss(EventFoodLoss)                 {}
+func (NopHandler) HandleHeal(EventHeal)                         {}
+func (NopHandler) HandleHurt(EventHurt)                         {}
+func (NopHandler) HandleItemConsume(EventItemConsume)           {}
+func (NopHandler) HandleItemDamage(EventItemDamage)             {}
+func (NopHandler) HandleItemDrop(EventItemDrop)                 {}
+func (NopHandler) HandleItemPickup(EventItemPickup)             {}
+func (NopHandler) HandleItemUse(EventItemUse)                   {}
+func (NopHandler) HandleItemUseOnBlock(EventItemUseOnBlock)     {}
+func (NopHandler) HandleItemUseOnEntity(EventItemUseOnEntity)   {}
+func (NopHandler) HandleJump(EventJump)                         {}
+func (NopHandler) HandleMove(EventMove)                         {}
+func (NopHandler) HandlePunchAir(EventPunchAir)                 {}
+func (NopHandler) HandleQuit(EventQuit)                         {}
+func (NopHandler) HandleRespawn(EventRespawn)                   {}
+func (NopHandler) HandleSignEdit(EventSignEdit)                 {}
+func (NopHandler) HandleSkinChange(EventSkinChange)             {}
+func (NopHandler) HandleStartBreak(EventStartBreak)             {}
+func (NopHandler) HandleTeleport(EventTeleport)                 {}
+func (NopHandler) HandleToggleSneak(EventToggleSneak)           {}
+func (NopHandler) HandleToggleSprint(EventToggleSprint)         {}
+func (NopHandler) HandleTransfer(EventTransfer)                 {}

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -1,18 +1,5 @@
 package player
 
-import (
-	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/cmd"
-	"github.com/df-mc/dragonfly/server/entity"
-	"github.com/df-mc/dragonfly/server/event"
-	"github.com/df-mc/dragonfly/server/item"
-	"github.com/df-mc/dragonfly/server/player/skin"
-	"github.com/df-mc/dragonfly/server/world"
-	"github.com/go-gl/mathgl/mgl64"
-	"net"
-	"time"
-)
-
 // Handler handles events that are called by a player. Implementations of Handler may be used to listen to
 // specific events such as when a player chats or moves.
 type Handler interface {

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -57,7 +57,7 @@ type Player struct {
 	// Player.session() should be called.
 	s atomic.Value[*session.Session]
 	// h holds the current Handler of the player. It may be changed at any time by calling the Handle method.
-	h atomic.Value[Handler]
+    handler atomic.Value[Handler]
 
 	inv, offHand, enderChest *inventory.Inventory
 	armour                   *inventory.Armour
@@ -118,16 +118,16 @@ func New(name string, skin skin.Skin, pos mgl64.Vec3) *Player {
 				p.broadcastItems(slot, before, after)
 			}
 		}),
-		enderChest:        inventory.New(27, nil),
-		uuid:              uuid.New(),
-		offHand:           inventory.New(1, p.broadcastItems),
-		armour:            inventory.NewArmour(p.broadcastArmour),
-		hunger:            newHungerManager(),
-		health:            entity.NewHealthManager(20, 20),
-		experience:        entity.NewExperienceManager(),
-		effects:           entity.NewEffectManager(),
-		gameMode:          *atomic.NewValue[world.GameMode](world.GameModeSurvival),
-		h:                 *atomic.NewValue[Handler](NopHandler{}),
+		enderChest: inventory.New(27, nil),
+		uuid:       uuid.New(),
+		offHand:    inventory.New(1, p.broadcastItems),
+		armour:     inventory.NewArmour(p.broadcastArmour),
+		hunger:     newHungerManager(),
+		health:     entity.NewHealthManager(20, 20),
+		experience: entity.NewExperienceManager(),
+		effects:    entity.NewEffectManager(),
+		gameMode:   *atomic.NewValue[world.GameMode](world.GameModeSurvival),
+        handler: *atomic.NewValue[Handler](NopHandler{}),
 		name:              name,
 		skin:              *atomic.NewValue(skin),
 		speed:             *atomic.NewFloat64(0.1),
@@ -241,7 +241,14 @@ func (p *Player) SetSkin(skin skin.Skin) {
 		return
 	}
 	ctx := event.C()
-	if p.Handler().HandleSkinChange(ctx, &skin); ctx.Cancelled() {
+
+	evt := EventSkinChange{
+		p,
+		&skin,
+		ctx,
+	}
+
+	if p.Handler().HandleSkinChange(evt); ctx.Cancelled() {
 		p.session().ViewSkin(p)
 		return
 	}
@@ -263,7 +270,7 @@ func (p *Player) Handle(h Handler) {
 	if h == nil {
 		h = NopHandler{}
 	}
-	p.h.Store(h)
+	p.handler.Store(h)
 }
 
 // Message sends a formatted message to the player. The message is formatted following the rules of
@@ -361,10 +368,18 @@ func (p *Player) RemoveBossBar() {
 func (p *Player) Chat(msg ...any) {
 	message := format(msg)
 	ctx := event.C()
-	if p.Handler().HandleChat(ctx, &message); ctx.Cancelled() {
+
+	evt := EventChat{
+		p,
+		&message,
+		ctx,
+	}
+
+	if p.Handler().HandleChat(evt); evt.Cancelled() {
 		return
 	}
-	_, _ = fmt.Fprintf(chat.Global, "<%v> %v\n", p.name, message)
+
+    _, _ = fmt.Fprintf(chat.Global, "<%v> %v\n", p.name, message)
 }
 
 // ExecuteCommand executes a command passed as the player. If the command could not be found, or if the usage
@@ -383,9 +398,18 @@ func (p *Player) ExecuteCommand(commandLine string) {
 		return
 	}
 	ctx := event.C()
-	if p.Handler().HandleCommandExecution(ctx, command, args[1:]); ctx.Cancelled() {
+
+	evt := EventCommandExecution{
+		p,
+		command,
+		args[1:],
+		ctx,
+	}
+
+	if p.Handler().HandleCommandExecution(evt); evt.Cancelled() {
 		return
 	}
+
 	command.Execute(strings.Join(args[1:], " "), p)
 }
 
@@ -398,7 +422,14 @@ func (p *Player) Transfer(address string) error {
 	}
 
 	ctx := event.C()
-	if p.Handler().HandleTransfer(ctx, addr); ctx.Cancelled() {
+
+	evt := EventTransfer{
+		p,
+		addr,
+		ctx,
+	}
+
+	if p.Handler().HandleTransfer(evt); evt.Cancelled() {
 		return nil
 	}
 	p.session().Transfer(addr.IP, addr.Port)
@@ -511,9 +542,18 @@ func (p *Player) Heal(health float64, source world.HealingSource) {
 		return
 	}
 	ctx := event.C()
-	if p.Handler().HandleHeal(ctx, &health, source); ctx.Cancelled() {
+
+	evt := EventHeal{
+		p,
+		&health,
+		source,
+		ctx,
+	}
+
+	if p.Handler().HandleHeal(evt); evt.Cancelled() {
 		return
 	}
+
 	p.addHealth(health)
 }
 
@@ -570,7 +610,16 @@ func (p *Player) Hurt(dmg float64, src world.DamageSource) (float64, bool) {
 	}
 	immunity := time.Second / 2
 	ctx := event.C()
-	if p.Handler().HandleHurt(ctx, &dmg, &immunity, src); ctx.Cancelled() {
+
+	evt := EventHurt{
+		p,
+		&dmg,
+		&immunity,
+		src,
+		ctx,
+	}
+
+	if p.Handler().HandleHurt(evt); evt.Cancelled() {
 		return 0, false
 	}
 	if dmg < 0 {
@@ -846,9 +895,18 @@ func (p *Player) Exhaust(points float64) {
 		p.hunger.SetFood(before)
 
 		ctx := event.C()
-		if p.Handler().HandleFoodLoss(ctx, before, &after); ctx.Cancelled() {
+
+		evt := EventFoodLoss{
+			p,
+			before,
+			&after,
+			ctx,
+		}
+
+		if p.Handler().HandleFoodLoss(evt); evt.Cancelled() {
 			return
 		}
+
 		p.hunger.SetFood(after)
 		if before >= 7 && after <= 6 {
 			// The client will stop sprinting by itself too, but we force it just to be sure.
@@ -884,7 +942,15 @@ func (p *Player) kill(src world.DamageSource) {
 	p.addHealth(-p.MaxHealth())
 
 	keepInv := false
-	p.Handler().HandleDeath(src, &keepInv)
+
+	evt := EventDeath{
+		p,
+		src,
+		&keepInv,
+	}
+
+	p.Handler().HandleDeath(evt)
+
 	p.StopSneaking()
 	p.StopSprinting()
 
@@ -955,7 +1021,13 @@ func (p *Player) Respawn() {
 	w = w.PortalDestination(w.Dimension())
 	pos := w.PlayerSpawn(p.UUID()).Vec3Middle()
 
-	p.Handler().HandleRespawn(&pos, &w)
+	evt := EventRespawn{
+		p,
+		&pos,
+		&w,
+	}
+
+	p.Handler().HandleRespawn(evt)
 
 	w.AddEntity(p)
 	p.Teleport(pos)
@@ -972,7 +1044,14 @@ func (p *Player) StartSprinting() {
 		return
 	}
 	ctx := event.C()
-	if p.Handler().HandleToggleSprint(ctx, true); ctx.Cancelled() {
+
+	evt := EventToggleSprint{
+		p,
+		true,
+		ctx,
+	}
+
+	if p.Handler().HandleToggleSprint(evt); evt.Cancelled() {
 		return
 	}
 	if !p.sprinting.CAS(false, true) {
@@ -992,7 +1071,14 @@ func (p *Player) Sprinting() bool {
 // StopSprinting makes a player stop sprinting, setting back the speed of the player to its original value.
 func (p *Player) StopSprinting() {
 	ctx := event.C()
-	if p.Handler().HandleToggleSprint(ctx, false); ctx.Cancelled() {
+
+	evt := EventToggleSprint{
+		p,
+		false,
+		ctx,
+	}
+
+	if p.Handler().HandleToggleSprint(evt); evt.Cancelled() {
 		return
 	}
 	if !p.sprinting.CAS(true, false) {
@@ -1008,7 +1094,14 @@ func (p *Player) StopSprinting() {
 // If the player is sprinting while StartSneaking is called, the sprinting is stopped.
 func (p *Player) StartSneaking() {
 	ctx := event.C()
-	if p.Handler().HandleToggleSneak(ctx, true); ctx.Cancelled() {
+
+	evt := EventToggleSneak{
+		p,
+		true,
+		ctx,
+	}
+
+	if p.Handler().HandleToggleSneak(evt); evt.Cancelled() {
 		return
 	}
 	if !p.sneaking.CAS(false, true) {
@@ -1029,7 +1122,14 @@ func (p *Player) Sneaking() bool {
 // will not do anything.
 func (p *Player) StopSneaking() {
 	ctx := event.C()
-	if p.Handler().HandleToggleSneak(ctx, false); ctx.Cancelled() {
+
+	evt := EventToggleSneak{
+		p,
+		false,
+		ctx,
+	}
+
+	if p.Handler().HandleToggleSneak(evt); evt.Cancelled() {
 		return
 	}
 	if !p.sneaking.CAS(true, false) {
@@ -1116,7 +1216,10 @@ func (p *Player) Jump() {
 		return
 	}
 
-	p.Handler().HandleJump()
+	evt := EventJump{p}
+
+	p.Handler().HandleJump(evt)
+
 	if p.OnGround() {
 		jumpVel := 0.42
 		if e, ok := p.Effect(effect.JumpBoost{}); ok {
@@ -1316,7 +1419,13 @@ func (p *Player) UseItem() {
 	if p.HasCooldown(i.Item()) {
 		return
 	}
-	if p.Handler().HandleItemUse(ctx); ctx.Cancelled() {
+
+	evt := EventItemUse{
+		p,
+		ctx,
+	}
+
+	if p.Handler().HandleItemUse(evt); evt.Cancelled() {
 		return
 	}
 	i, left = p.HeldItems()
@@ -1372,7 +1481,14 @@ func (p *Player) UseItem() {
 		}
 
 		ctx = event.C()
-		if p.Handler().HandleItemConsume(ctx, i); ctx.Cancelled() {
+
+		evt := EventItemConsume{
+			p,
+			i,
+			ctx,
+		}
+
+		if p.Handler().HandleItemConsume(evt); evt.Cancelled() {
 			// Consuming was cancelled, but the client will continue consuming the next item.
 			p.usingSince.Store(time.Now().UnixNano())
 			return
@@ -1462,7 +1578,16 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 		return
 	}
 	ctx := event.C()
-	if p.Handler().HandleItemUseOnBlock(ctx, pos, face, clickPos); ctx.Cancelled() {
+
+	evt := EventItemUseOnBlock{
+		p,
+		pos,
+		face,
+		clickPos,
+		ctx,
+	}
+
+	if p.Handler().HandleItemUseOnBlock(evt); evt.Cancelled() {
 		p.resendBlocks(pos, w, face)
 		return
 	}
@@ -1521,7 +1646,14 @@ func (p *Player) UseItemOnEntity(e world.Entity) bool {
 		return false
 	}
 	ctx := event.C()
-	if p.Handler().HandleItemUseOnEntity(ctx, e); ctx.Cancelled() {
+
+	evt := EventItemUseOnEntity{
+		p,
+		e,
+		ctx,
+	}
+
+	if p.Handler().HandleItemUseOnEntity(evt); evt.Cancelled() {
 		return false
 	}
 	i, left := p.HeldItems()
@@ -1556,9 +1688,20 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 	)
 
 	ctx := event.C()
-	if p.Handler().HandleAttackEntity(ctx, e, &force, &height, &critical); ctx.Cancelled() {
+
+	evt := EventAttackEntity{
+		p,
+		e,
+		&force,
+		&height,
+		&critical,
+		ctx,
+	}
+
+	if p.Handler().HandleAttackEntity(evt); evt.Cancelled() {
 		return false
 	}
+
 	p.SwingArm()
 
 	i, _ := p.HeldItems()
@@ -1647,7 +1790,14 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	p.breakingPos.Store(pos)
 
 	ctx := event.C()
-	if p.Handler().HandleStartBreak(ctx, pos); ctx.Cancelled() {
+
+	evt := EventStartBreak{
+		p,
+		pos,
+		ctx,
+	}
+
+	if p.Handler().HandleStartBreak(evt); evt.Cancelled() {
 		return
 	}
 	if punchable, ok := w.Block(pos).(block.Punchable); ok {
@@ -1775,10 +1925,19 @@ func (p *Player) placeBlock(pos cube.Pos, b world.Block, ignoreBBox bool) bool {
 	}
 
 	ctx := event.C()
-	if p.Handler().HandleBlockPlace(ctx, pos, b); ctx.Cancelled() {
+
+	evt := EventBlockPlace{
+		p,
+		pos,
+		b,
+		ctx,
+	}
+
+	if p.Handler().HandleBlockPlace(evt); evt.Cancelled() {
 		p.resendBlocks(pos, w, cube.Faces()...)
 		return false
 	}
+
 	w.SetBlock(pos, b, nil)
 	w.PlaySound(pos.Vec3(), sound.BlockPlace{Block: b})
 	p.SwingArm()
@@ -1834,10 +1993,20 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	}
 
 	ctx := event.C()
-	if p.Handler().HandleBlockBreak(ctx, pos, &drops, &xp); ctx.Cancelled() {
+
+	evt := EventBlockBreak{
+		p,
+		pos,
+		&drops,
+		&xp,
+		ctx,
+	}
+
+	if p.Handler().HandleBlockBreak(evt); evt.Cancelled() {
 		p.resendBlocks(pos, w)
 		return
 	}
+
 	held, left := p.HeldItems()
 
 	p.SwingArm()
@@ -1921,9 +2090,18 @@ func (p *Player) PickBlock(pos cube.Pos) {
 	}
 
 	ctx := event.C()
-	if p.Handler().HandleBlockPick(ctx, pos, b); ctx.Cancelled() {
+
+	evt := EventBlockPick{
+		p,
+		pos,
+		b,
+		ctx,
+	}
+
+	if p.Handler().HandleBlockPick(evt); evt.Cancelled() {
 		return
 	}
+
 	_, offhand := p.HeldItems()
 
 	if found {
@@ -1953,7 +2131,14 @@ func (p *Player) PickBlock(pos cube.Pos) {
 // position of the player, rather than showing an animation.
 func (p *Player) Teleport(pos mgl64.Vec3) {
 	ctx := event.C()
-	if p.Handler().HandleTeleport(ctx, pos); ctx.Cancelled() {
+
+	evt := EventTeleport{
+		p,
+		pos,
+		ctx,
+	}
+
+	if p.Handler().HandleTeleport(evt); evt.Cancelled() {
 		return
 	}
 	p.teleport(pos)
@@ -1992,7 +2177,16 @@ func (p *Player) Move(deltaPos mgl64.Vec3, deltaYaw, deltaPitch float64) {
 		res, resYaw, resPitch = pos.Add(deltaPos), yaw + deltaYaw, pitch + deltaPitch
 	)
 	ctx := event.C()
-	if p.Handler().HandleMove(ctx, res, resYaw, resPitch); ctx.Cancelled() {
+
+	evt := EventMove{
+		p,
+		res,
+		resYaw,
+		resPitch,
+		ctx,
+	}
+
+	if p.Handler().HandleMove(evt); evt.Cancelled() {
 		if p.session() != session.Nop && pos.ApproxEqual(p.Position()) {
 			// The position of the player was changed and the event cancelled. This means we still need to notify the
 			// player of this movement change.
@@ -2091,7 +2285,14 @@ func (p *Player) Collect(s item.Stack) int {
 		return 0
 	}
 	ctx := event.C()
-	if p.Handler().HandleItemPickup(ctx, s); ctx.Cancelled() {
+
+	evt := EventItemPickup{
+		p,
+		s,
+		ctx,
+	}
+
+	if p.Handler().HandleItemPickup(evt); evt.Cancelled() {
 		return 0
 	}
 	n, _ := p.Inventory().AddItem(s)
@@ -2116,9 +2317,17 @@ func (p *Player) ResetEnchantmentSeed() {
 // AddExperience adds experience to the player.
 func (p *Player) AddExperience(amount int) int {
 	ctx := event.C()
-	if p.Handler().HandleExperienceGain(ctx, &amount); ctx.Cancelled() {
+
+	evt := EventExperienceGain{
+		p,
+		&amount,
+		ctx,
+	}
+
+	if p.Handler().HandleExperienceGain(evt); evt.Cancelled() {
 		return 0
 	}
+
 	before := p.experience.Level()
 	level, _ := p.experience.Add(amount)
 	if level/5 > before/5 {
@@ -2231,7 +2440,14 @@ func (p *Player) Drop(s item.Stack) int {
 	e.SetPickupDelay(time.Second * 2)
 
 	ctx := event.C()
-	if p.Handler().HandleItemDrop(ctx, e); ctx.Cancelled() {
+
+	evt := EventItemDrop{
+		p,
+		e,
+		ctx,
+	}
+
+	if p.Handler().HandleItemDrop(evt); evt.Cancelled() {
 		return 0
 	}
 	p.World().AddEntity(e)
@@ -2280,7 +2496,13 @@ func (p *Player) Tick(w *world.World, current int64) {
 		return
 	}
 	if p.lastTickedWorld != w {
-		p.Handler().HandleChangeWorld(p.lastTickedWorld, w)
+		evt := EventChangeWorld{
+			p,
+			p.lastTickedWorld,
+			w,
+		}
+
+		p.Handler().HandleChangeWorld(evt)
 	}
 	p.lastTickedWorld = w
 	if _, ok := w.Liquid(cube.PosFromVec3(p.Position())); !ok {
@@ -2659,7 +2881,15 @@ func (p *Player) EditSign(pos cube.Pos, text string) error {
 	}
 
 	ctx := event.C()
-	if p.Handler().HandleSignEdit(ctx, sign.Text, text); ctx.Cancelled() {
+
+	evt := EventSignEdit{
+		p,
+		sign,
+		&text,
+		ctx,
+	}
+
+	if p.Handler().HandleSignEdit(evt); evt.Cancelled() {
 		return nil
 	}
 	sign.Text = text
@@ -2700,7 +2930,13 @@ func (p *Player) PunchAir() {
 		return
 	}
 	ctx := event.C()
-	if p.Handler().HandlePunchAir(ctx); ctx.Cancelled() {
+
+	evt := EventPunchAir{
+		p,
+		ctx,
+	}
+
+	if p.Handler().HandlePunchAir(evt); evt.Cancelled() {
 		return
 	}
 	p.SwingArm()
@@ -2715,9 +2951,18 @@ func (p *Player) damageItem(s item.Stack, d int) item.Stack {
 		return s
 	}
 	ctx := event.C()
-	if p.Handler().HandleItemDamage(ctx, s, d); ctx.Cancelled() {
+
+	evt := EventItemDamage{
+		p,
+		s,
+		d,
+		ctx,
+	}
+
+	if p.Handler().HandleItemDamage(evt); evt.Cancelled() {
 		return s
 	}
+
 	if e, ok := s.Enchantment(enchantment.Unbreaking{}); ok {
 		d = (enchantment.Unbreaking{}).Reduce(s.Item(), e.Level(), d)
 	}
@@ -2801,7 +3046,10 @@ func (p *Player) close(msg string) {
 	if p.Dead() && p.session() != nil {
 		p.Respawn()
 	}
-	p.h.Swap(NopHandler{}).HandleQuit()
+
+	evt := EventQuit{p}
+
+    p.handler.Swap(NopHandler{}).HandleQuit(evt)
 
 	if s := p.s.Swap(nil); s != nil {
 		s.Disconnect(msg)
@@ -2915,18 +3163,37 @@ func (p *Player) session() *session.Session {
 	return session.Nop
 }
 
+func call[T callConstraint](
+	inv *inventory.Inventory,
+	slot int, it item.Stack,
+	ctx *event.Context,
+	f func(T),
+) error {
+	if ctx.Cancelled() {
+		return fmt.Errorf("action was cancelled")
+	}
+
+	evt := T {
+		inv,
+		slot,
+		it,
+		ctx,
+	}
+
+	if f(evt); evt.Cancelled() {
+		return fmt.Errorf("action was cancelled")
+	}
+
+	return nil
+}
+
+type callConstraint interface {
+	Cancelled() bool
+	inventory.EventDrop | inventory.EventPlace | inventory.EventTake
+}
+
 // useContext returns an item.UseContext initialised for a Player.
 func (p *Player) useContext() *item.UseContext {
-	call := func(ctx *event.Context, slot int, it item.Stack, f func(ctx *event.Context, slot int, it item.Stack)) error {
-		if ctx.Cancelled() {
-			return fmt.Errorf("action was cancelled")
-		}
-		f(ctx, slot, it)
-		if ctx.Cancelled() {
-			return fmt.Errorf("action was cancelled")
-		}
-		return nil
-	}
 	return &item.UseContext{
 		SwapHeldWithArmour: func(i int) {
 			src, dst, srcInv, dstInv := int(p.heldSlot.Load()), i, p.inv, p.armour.Inventory()
@@ -2934,10 +3201,10 @@ func (p *Player) useContext() *item.UseContext {
 			dstIt, _ := dstInv.Item(dst)
 
 			ctx := event.C()
-			_ = call(ctx, src, srcIt, srcInv.Handler().HandleTake)
-			_ = call(ctx, src, dstIt, srcInv.Handler().HandlePlace)
-			_ = call(ctx, dst, dstIt, dstInv.Handler().HandleTake)
-			if err := call(ctx, dst, srcIt, dstInv.Handler().HandlePlace); err == nil {
+			_ = call[inventory.EventTake](srcInv, src, srcIt, ctx, srcInv.Handler().HandleTake)
+			_ = call[inventory.EventPlace](srcInv, src, dstIt, ctx, srcInv.Handler().HandlePlace)
+			_ = call[inventory.EventTake](dstInv, dst, dstIt, ctx, dstInv.Handler().HandleTake)
+			if err := call[inventory.EventPlace](dstInv, dst, srcIt, ctx, dstInv.Handler().HandlePlace); err == nil {
 				_ = srcInv.SetItem(src, dstIt)
 				_ = dstInv.SetItem(dst, srcIt)
 				p.PlaySound(sound.EquipItem{Item: srcIt.Item()})
@@ -2957,7 +3224,7 @@ func (p *Player) useContext() *item.UseContext {
 
 // Handler returns the Handler of the player.
 func (p *Player) Handler() Handler {
-	return p.h.Load()
+	return p.handler.Load()
 }
 
 // broadcastItems broadcasts the items held to viewers.

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -57,7 +57,7 @@ type Player struct {
 	// Player.session() should be called.
 	s atomic.Value[*session.Session]
 	// h holds the current Handler of the player. It may be changed at any time by calling the Handle method.
-    handler atomic.Value[Handler]
+	handler atomic.Value[Handler]
 
 	inv, offHand, enderChest *inventory.Inventory
 	armour                   *inventory.Armour
@@ -118,16 +118,16 @@ func New(name string, skin skin.Skin, pos mgl64.Vec3) *Player {
 				p.broadcastItems(slot, before, after)
 			}
 		}),
-		enderChest: inventory.New(27, nil),
-		uuid:       uuid.New(),
-		offHand:    inventory.New(1, p.broadcastItems),
-		armour:     inventory.NewArmour(p.broadcastArmour),
-		hunger:     newHungerManager(),
-		health:     entity.NewHealthManager(20, 20),
-		experience: entity.NewExperienceManager(),
-		effects:    entity.NewEffectManager(),
-		gameMode:   *atomic.NewValue[world.GameMode](world.GameModeSurvival),
-        handler: *atomic.NewValue[Handler](NopHandler{}),
+		enderChest:        inventory.New(27, nil),
+		uuid:              uuid.New(),
+		offHand:           inventory.New(1, p.broadcastItems),
+		armour:            inventory.NewArmour(p.broadcastArmour),
+		hunger:            newHungerManager(),
+		health:            entity.NewHealthManager(20, 20),
+		experience:        entity.NewExperienceManager(),
+		effects:           entity.NewEffectManager(),
+		gameMode:          *atomic.NewValue[world.GameMode](world.GameModeSurvival),
+		handler:           *atomic.NewValue[Handler](NopHandler{}),
 		name:              name,
 		skin:              *atomic.NewValue(skin),
 		speed:             *atomic.NewFloat64(0.1),
@@ -379,7 +379,7 @@ func (p *Player) Chat(msg ...any) {
 		return
 	}
 
-    _, _ = fmt.Fprintf(chat.Global, "<%v> %v\n", p.name, message)
+	_, _ = fmt.Fprintf(chat.Global, "<%v> %v\n", p.name, message)
 }
 
 // ExecuteCommand executes a command passed as the player. If the command could not be found, or if the usage
@@ -3049,7 +3049,7 @@ func (p *Player) close(msg string) {
 
 	evt := EventQuit{p}
 
-    p.handler.Swap(NopHandler{}).HandleQuit(evt)
+	p.handler.Swap(NopHandler{}).HandleQuit(evt)
 
 	if s := p.s.Swap(nil); s != nil {
 		s.Disconnect(msg)
@@ -3173,7 +3173,7 @@ func call[T callConstraint](
 		return fmt.Errorf("action was cancelled")
 	}
 
-	evt := T {
+	evt := T{
 		inv,
 		slot,
 		it,

--- a/server/session/handler_inventory_transaction.go
+++ b/server/session/handler_inventory_transaction.go
@@ -75,7 +75,7 @@ func (h *InventoryTransactionHandler) handleNormalTransaction(pk *packet.Invento
 				return fmt.Errorf("tried to throw %v items, but held only %v in slot", thrown.Count(), held.Count())
 			}
 
-			if err := call(event.C(), int(s.heldSlot.Load()), held.Grow(thrown.Count()-held.Count()), s.inv.Handler().HandleDrop); err != nil {
+			if err := call(s.inv, int(s.heldSlot.Load()), held.Grow(thrown.Count()-held.Count()), event.C(), s.inv.Handler().HandleDrop); err != nil {
 				return err
 			}
 

--- a/server/session/handler_item_stack_request.go
+++ b/server/session/handler_item_stack_request.go
@@ -165,8 +165,8 @@ func (h *ItemStackRequestHandler) handleTransfer(from, to protocol.StackRequestS
 	invB, _ := s.invByID(int32(to.ContainerID))
 
 	ctx := event.C()
-	_ = call(ctx, int(from.Slot), i.Grow(int(count)-i.Count()), invA.Handler().HandleTake)
-	err := call(ctx, int(to.Slot), i.Grow(int(count)-i.Count()), invB.Handler().HandlePlace)
+	_ = call(invA, int(from.Slot), i.Grow(int(count)-i.Count()), ctx, invA.Handler().HandleTake)
+	err := call(invB, int(to.Slot), i.Grow(int(count)-i.Count()), ctx, invB.Handler().HandlePlace)
 	if err != nil {
 		return err
 	}
@@ -189,10 +189,10 @@ func (h *ItemStackRequestHandler) handleSwap(a *protocol.SwapStackRequestAction,
 	invB, _ := s.invByID(int32(a.Destination.ContainerID))
 
 	ctx := event.C()
-	_ = call(ctx, int(a.Source.Slot), i, invA.Handler().HandleTake)
-	_ = call(ctx, int(a.Source.Slot), dest, invA.Handler().HandlePlace)
-	_ = call(ctx, int(a.Destination.Slot), dest, invB.Handler().HandleTake)
-	err := call(ctx, int(a.Destination.Slot), i, invB.Handler().HandlePlace)
+	_ = call(invA, int(a.Source.Slot), i, ctx, invA.Handler().HandleTake)
+	_ = call(invA, int(a.Source.Slot), dest, ctx, invA.Handler().HandlePlace)
+	_ = call(invB, int(a.Destination.Slot), dest, ctx, invB.Handler().HandleTake)
+	err := call(invB, int(a.Destination.Slot), i, ctx, invB.Handler().HandlePlace)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (h *ItemStackRequestHandler) handleDrop(a *protocol.DropStackRequestAction,
 	}
 
 	inv, _ := s.invByID(int32(a.Source.ContainerID))
-	if err := call(event.C(), int(a.Source.Slot), i.Grow(int(a.Count)-i.Count()), inv.Handler().HandleDrop); err != nil {
+	if err := call(inv, int(a.Source.Slot), i.Grow(int(a.Count)-i.Count()), event.C(), inv.Handler().HandleDrop); err != nil {
 		return err
 	}
 
@@ -500,14 +500,26 @@ func (h *ItemStackRequestHandler) reject(id int32, s *Session) {
 	h.pendingResults = nil
 }
 
+type callConstraint interface {
+	Cancelled() bool
+	inventory.EventDrop | inventory.EventPlace | inventory.EventTake
+}
+
 // call uses an event.Context, slot and item.Stack to call the event handler function passed. An error is returned if
 // the event.Context was cancelled either before or after the call.
-func call(ctx *event.Context, slot int, it item.Stack, f func(ctx *event.Context, slot int, it item.Stack)) error {
+func call[T callConstraint](inv *inventory.Inventory, slot int, it item.Stack, ctx *event.Context, f func(T)) error {
 	if ctx.Cancelled() {
 		return fmt.Errorf("action was cancelled")
 	}
-	f(ctx, slot, it)
-	if ctx.Cancelled() {
+
+	evt := T{
+		inv,
+		slot,
+		it,
+		ctx,
+	}
+
+	if f(evt); evt.Cancelled() {
 		return fmt.Errorf("action was cancelled")
 	}
 	return nil

--- a/server/world/events.go
+++ b/server/world/events.go
@@ -1,0 +1,67 @@
+package world
+
+import (
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/event"
+	"github.com/go-gl/mathgl/mgl64"
+)
+
+type EventBlockBurn struct {
+	World    *World
+	Position cube.Pos
+	*event.Context
+}
+
+type EventClose struct {
+	World *World
+}
+
+type EventEntityDespawn struct {
+	World  *World
+	Entity Entity
+}
+
+type EventEntitySpawn struct {
+	World  *World
+	Entity Entity
+}
+
+type EventFireSpread struct {
+	World *World
+	From  cube.Pos
+	To    cube.Pos
+	*event.Context
+}
+
+type EventLiquidDecay struct {
+	World    *World
+	Position cube.Pos
+	From     Liquid
+	To       Liquid
+	*event.Context
+}
+
+type EventLiquidFlow struct {
+	World    *World
+	From     cube.Pos
+	To       cube.Pos
+	Liquid   Liquid
+	Replaced Block
+	*event.Context
+}
+
+type EventLiquidHarden struct {
+	World          *World
+	Position       cube.Pos
+	LiquidHardened Block
+	OtherLiquid    Block
+	NewBlock       Block
+	*event.Context
+}
+
+type EventSound struct {
+	World    *World
+	Position mgl64.Vec3
+	Sound    Sound
+	*event.Context
+}

--- a/server/world/handler.go
+++ b/server/world/handler.go
@@ -47,12 +47,12 @@ var _ Handler = (*NopHandler)(nil)
 // Users may embed NopHandler to avoid having to implement each method.
 type NopHandler struct{}
 
-func (NopHandler) HandleLiquidFlow(EventLiquidFlow) {}
-func (NopHandler) HandleLiquidDecay(EventLiquidDecay)         {}
+func (NopHandler) HandleLiquidFlow(EventLiquidFlow)       {}
+func (NopHandler) HandleLiquidDecay(EventLiquidDecay)     {}
 func (NopHandler) HandleLiquidHarden(EventLiquidHarden)   {}
-func (NopHandler) HandleSound(EventSound)                      {}
-func (NopHandler) HandleFireSpread(EventFireSpread)                {}
-func (NopHandler) HandleBlockBurn(EventBlockBurn)                           {}
-func (NopHandler) HandleEntitySpawn(EventEntitySpawn)                                           {}
-func (NopHandler) HandleEntityDespawn(EventEntityDespawn)                                         {}
-func (NopHandler) HandleClose(EventClose)                                                       {}
+func (NopHandler) HandleSound(EventSound)                 {}
+func (NopHandler) HandleFireSpread(EventFireSpread)       {}
+func (NopHandler) HandleBlockBurn(EventBlockBurn)         {}
+func (NopHandler) HandleEntitySpawn(EventEntitySpawn)     {}
+func (NopHandler) HandleEntityDespawn(EventEntityDespawn) {}
+func (NopHandler) HandleClose(EventClose)                 {}

--- a/server/world/handler.go
+++ b/server/world/handler.go
@@ -1,11 +1,5 @@
 package world
 
-import (
-	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/event"
-	"github.com/go-gl/mathgl/mgl64"
-)
-
 // Handler handles events that are called by a world. Implementations of Handler may be used to listen to
 // specific events such as when an entity is added to the world.
 type Handler interface {
@@ -13,36 +7,36 @@ type Handler interface {
 	// position into. The liquid that will replace the block is also passed. This replaced block might
 	// also be a Liquid. The Liquid's depth and falling state can be checked to see if the resulting
 	// liquid is a new source block (in the case of water).
-	HandleLiquidFlow(ctx *event.Context, from, into cube.Pos, liquid Liquid, replaced Block)
+	HandleLiquidFlow(EventLiquidFlow)
 	// HandleLiquidDecay handles the decaying of a Liquid block at a position. Liquid decaying happens
 	// when there is no Liquid that can serve as the source block neighbouring it. The state of the
 	// Liquid before and after the decaying is passed. The Liquid after is nil if the liquid is
 	// completely removed as a result of the decay.
-	HandleLiquidDecay(ctx *event.Context, pos cube.Pos, before, after Liquid)
+	HandleLiquidDecay(EventLiquidDecay)
 	// HandleLiquidHarden handles the hardening of a liquid at hardenedPos. The liquid that was hardened,
 	// liquidHardened, and the liquid that caused it to harden, otherLiquid, are passed. The block created
 	// as a result is also passed.
-	HandleLiquidHarden(ctx *event.Context, hardenedPos cube.Pos, liquidHardened, otherLiquid, newBlock Block)
+	HandleLiquidHarden(EventLiquidHarden)
 	// HandleSound handles a Sound being played in the World at a specific position. ctx.Cancel() may be called
 	// to stop the Sound from playing to viewers of the position.
-	HandleSound(ctx *event.Context, s Sound, pos mgl64.Vec3)
+	HandleSound(EventSound)
 	// HandleFireSpread handles when a fire block spreads from one block to another block. When this event handler gets
 	// called, both the position of the original fire will be passed, and the position where it will spread to after the
 	// event. The age of the fire may also be altered by changing the underlying value of the newFireAge pointer, which
 	// decides how long the fire will stay before burning out.
-	HandleFireSpread(ctx *event.Context, from, to cube.Pos)
+	HandleFireSpread(EventFireSpread)
 	// HandleBlockBurn handles a block at a cube.Pos being burnt by fire. This event may be called for blocks such as
 	// wood, that can be broken by fire. HandleBlockBurn is often succeeded by HandleFireSpread, when fire spreads to
 	// the position of the original block and the event.Context is not cancelled in HandleBlockBurn.
-	HandleBlockBurn(ctx *event.Context, pos cube.Pos)
+	HandleBlockBurn(EventBlockBurn)
 	// HandleEntitySpawn handles an entity being spawned into a World through a call to World.AddEntity.
-	HandleEntitySpawn(e Entity)
+	HandleEntitySpawn(EventEntitySpawn)
 	// HandleEntityDespawn handles an entity being despawned from a World through a call to World.RemoveEntity.
-	HandleEntityDespawn(e Entity)
+	HandleEntityDespawn(EventEntityDespawn)
 	// HandleClose handles the World being closed. HandleClose may be used as a moment to finish code running on other
 	// goroutines that operates on the World specifically. HandleClose is called directly before the World stops
 	// ticking and before any chunks are saved to disk.
-	HandleClose()
+	HandleClose(EventClose)
 }
 
 // Compile time check to make sure NopHandler implements Handler.
@@ -53,12 +47,12 @@ var _ Handler = (*NopHandler)(nil)
 // Users may embed NopHandler to avoid having to implement each method.
 type NopHandler struct{}
 
-func (NopHandler) HandleLiquidFlow(*event.Context, cube.Pos, cube.Pos, Liquid, Block) {}
-func (NopHandler) HandleLiquidDecay(*event.Context, cube.Pos, Liquid, Liquid)         {}
-func (NopHandler) HandleLiquidHarden(*event.Context, cube.Pos, Block, Block, Block)   {}
-func (NopHandler) HandleSound(*event.Context, Sound, mgl64.Vec3)                      {}
-func (NopHandler) HandleFireSpread(*event.Context, cube.Pos, cube.Pos)                {}
-func (NopHandler) HandleBlockBurn(*event.Context, cube.Pos)                           {}
-func (NopHandler) HandleEntitySpawn(Entity)                                           {}
-func (NopHandler) HandleEntityDespawn(Entity)                                         {}
-func (NopHandler) HandleClose()                                                       {}
+func (NopHandler) HandleLiquidFlow(EventLiquidFlow) {}
+func (NopHandler) HandleLiquidDecay(EventLiquidDecay)         {}
+func (NopHandler) HandleLiquidHarden(EventLiquidHarden)   {}
+func (NopHandler) HandleSound(EventSound)                      {}
+func (NopHandler) HandleFireSpread(EventFireSpread)                {}
+func (NopHandler) HandleBlockBurn(EventBlockBurn)                           {}
+func (NopHandler) HandleEntitySpawn(EventEntitySpawn)                                           {}
+func (NopHandler) HandleEntityDespawn(EventEntityDespawn)                                         {}
+func (NopHandler) HandleClose(EventClose)                                                       {}

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/df-mc/atomic"
+    "github.com/df-mc/atomic"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/internal/sliceutil"
@@ -31,8 +31,8 @@ type World struct {
 
 	o sync.Once
 
-	set     *Settings
-	handler atomic.Value[Handler]
+	set *Settings
+    handler atomic.Value[Handler]
 
 	weather
 	ticker
@@ -646,7 +646,15 @@ func (w *World) AddParticle(pos mgl64.Vec3, p Particle) {
 // the sound if they're close enough.
 func (w *World) PlaySound(pos mgl64.Vec3, s Sound) {
 	ctx := event.C()
-	if w.Handler().HandleSound(ctx, s, pos); ctx.Cancelled() {
+
+	evt := EventSound{
+		w,
+		pos,
+		s,
+		ctx,
+	}
+
+	if w.Handler().HandleSound(evt); evt.Cancelled() {
 		return
 	}
 	for _, viewer := range w.Viewers(pos) {
@@ -690,7 +698,12 @@ func (w *World) AddEntity(e Entity) {
 		showEntity(e, v)
 	}
 
-	w.Handler().HandleEntitySpawn(e)
+	evt := EventEntitySpawn{
+		w,
+		e,
+	}
+
+	w.Handler().HandleEntitySpawn(evt)
 }
 
 // add maps an Entity to a World in the entityWorlds map.
@@ -718,7 +731,12 @@ func (w *World) RemoveEntity(e Entity) {
 		return
 	}
 
-	w.Handler().HandleEntityDespawn(e)
+	evt := EventEntityDespawn{
+		w,
+		e,
+	}
+
+	w.Handler().HandleEntityDespawn(evt)
 
 	worldsMu.Lock()
 	delete(entityWorlds, e)
@@ -1015,8 +1033,9 @@ func (w *World) Close() error {
 // close stops the World from ticking, saves all chunks to the Provider and updates the world's settings.
 func (w *World) close() {
 	// Let user code run anything that needs to be finished before the World is closed.
-	w.Handler().HandleClose()
-	w.Handle(NopHandler{})
+	evt := EventClose{w}
+
+	w.handler.Swap(NopHandler{}).HandleClose(evt)
 
 	close(w.closing)
 	w.running.Wait()

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-    "github.com/df-mc/atomic"
+	"github.com/df-mc/atomic"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/internal/sliceutil"
@@ -31,8 +31,8 @@ type World struct {
 
 	o sync.Once
 
-	set *Settings
-    handler atomic.Value[Handler]
+	set     *Settings
+	handler atomic.Value[Handler]
 
 	weather
 	ticker


### PR DESCRIPTION
This PR implements event structs. Event structs represent specific events, for example, the player chat event or the world liquid harden event. Event handler functions such as HandleChat, or HandleLiquidHarden consequently take an event struct as opposed to zero, single or multiple arguments. Using structs to represent events in favour of individual arguments improves code readability and is more backwards compatible, as new event variables, for example adding a pointer to a string that represents player chat prefix as an argument to HandleChat, will no longer cause breaking changes.

Each event struct contains a pointer to the 'main actor' of the event. For example, in each player event struct there is a pointer to the player that event revolves around. In my opinion this is preferable to the current format that does not provide the 'main actor' to the handler function directly, where the player must be either stored in the handler struct, or the function must be defined in a scope which already defines the player it needs access to. It seems to me that it is only logical that the 'main actor' around which the entire event is based should be given directly to the handler function along with other attributes about that event. The following is an example of what the event struct system looks like:

```
type MyHandler struct {
    player.NopHandler
}

func (MyHandler) HandleChat(e player.EventChat) {
    filterChat(e)
    styleChat(e)
}

func filterChat(e player.EventChat) {
    if *e.Message = "crap" {
        e.Cancel()
    }
}

func styleChat(e player.EventChat) {}
```
For events that can be cancelled, the ctx has been embedded into the event struct, so that one may call Cancel() or Cancelled() directly on 'e', as shown above.

I am aware that comments have not been changed/added, but will perhaps need to be, I wanted to discuss that here before I made any changes. In my opinion, the comments above each handler interface function definition should be removed, and new comments made above each event struct. I am willing to do this, if desired. The new comments would be in most cases identical to the old ones, but improved grammatically, where applicable.