### PR TITLE
add uniqueID to all entities and save using actorstorage

### DIFF
--- a/server/entity/arrow.go
+++ b/server/entity/arrow.go
@@ -1,6 +1,9 @@
 package entity
 
 import (
+	"math/rand"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/internal/nbtconv"
 	"github.com/df-mc/dragonfly/server/item"
@@ -9,7 +12,6 @@ import (
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/sound"
 	"github.com/go-gl/mathgl/mgl64"
-	"time"
 )
 
 // NewArrow creates a new Arrow and returns it. It is equivalent to calling NewTippedArrow with `potion.Potion{}` as
@@ -37,6 +39,7 @@ func NewTippedArrowWithDamage(pos mgl64.Vec3, yaw, pitch, damage float64, owner 
 	conf.Potion = tip
 	a := Config{Behaviour: conf.New(owner)}.New(ArrowType{}, pos)
 	a.rot = cube.Rotation{yaw, pitch}
+	a.uniqueID = rand.Int63()
 	return a
 }
 
@@ -67,6 +70,9 @@ func (ArrowType) BBox(world.Entity) cube.BBox {
 func (ArrowType) DecodeNBT(m map[string]any) world.Entity {
 	pot := potion.From(nbtconv.Int32(m, "auxValue") - 1)
 	arr := NewTippedArrowWithDamage(nbtconv.Vec3(m, "Pos"), float64(nbtconv.Float32(m, "Yaw")), float64(nbtconv.Float32(m, "Pitch")), float64(nbtconv.Float32(m, "Damage")), nil, pot)
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		arr.uniqueID = uniqueID
+	}
 	b := arr.conf.Behaviour.(*ProjectileBehaviour)
 	arr.vel = nbtconv.Vec3(m, "Motion")
 	b.conf.DisablePickup = !nbtconv.Bool(m, "player")

--- a/server/entity/bottle_of_enchanting.go
+++ b/server/entity/bottle_of_enchanting.go
@@ -1,6 +1,8 @@
 package entity
 
 import (
+	"math/rand"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/cube/trace"
 	"github.com/df-mc/dragonfly/server/internal/nbtconv"
@@ -8,7 +10,6 @@ import (
 	"github.com/df-mc/dragonfly/server/world/particle"
 	"github.com/df-mc/dragonfly/server/world/sound"
 	"github.com/go-gl/mathgl/mgl64"
-	"math/rand"
 )
 
 // NewBottleOfEnchanting ...
@@ -52,13 +53,17 @@ func (BottleOfEnchantingType) BBox(world.Entity) cube.BBox {
 func (BottleOfEnchantingType) DecodeNBT(m map[string]any) world.Entity {
 	b := NewBottleOfEnchanting(nbtconv.Vec3(m, "Pos"), nil)
 	b.vel = nbtconv.Vec3(m, "Motion")
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		b.uniqueID = uniqueID
+	}
 	return b
 }
 
 func (BottleOfEnchantingType) EncodeNBT(e world.Entity) map[string]any {
 	b := e.(*Ent)
 	return map[string]any{
-		"Pos":    nbtconv.Vec3ToFloat32Slice(b.Position()),
-		"Motion": nbtconv.Vec3ToFloat32Slice(b.Velocity()),
+		"UniqueID": b.uniqueID,
+		"Pos":      nbtconv.Vec3ToFloat32Slice(b.Position()),
+		"Motion":   nbtconv.Vec3ToFloat32Slice(b.Velocity()),
 	}
 }

--- a/server/entity/egg.go
+++ b/server/entity/egg.go
@@ -33,13 +33,17 @@ func (EggType) BBox(world.Entity) cube.BBox {
 func (EggType) DecodeNBT(m map[string]any) world.Entity {
 	egg := NewEgg(nbtconv.Vec3(m, "Pos"), nil)
 	egg.vel = nbtconv.Vec3(m, "Motion")
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		egg.uniqueID = uniqueID
+	}
 	return egg
 }
 
 func (EggType) EncodeNBT(e world.Entity) map[string]any {
 	egg := e.(*Ent)
 	return map[string]any{
-		"Pos":    nbtconv.Vec3ToFloat32Slice(egg.Position()),
-		"Motion": nbtconv.Vec3ToFloat32Slice(egg.Velocity()),
+		"UniqueID": egg.uniqueID,
+		"Pos":      nbtconv.Vec3ToFloat32Slice(egg.Position()),
+		"Motion":   nbtconv.Vec3ToFloat32Slice(egg.Velocity()),
 	}
 }

--- a/server/entity/ender_pearl.go
+++ b/server/entity/ender_pearl.go
@@ -51,13 +51,17 @@ func (EnderPearlType) BBox(world.Entity) cube.BBox {
 func (EnderPearlType) DecodeNBT(m map[string]any) world.Entity {
 	ep := NewEnderPearl(nbtconv.Vec3(m, "Pos"), nil)
 	ep.vel = nbtconv.Vec3(m, "Motion")
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		ep.uniqueID = uniqueID
+	}
 	return ep
 }
 
 func (EnderPearlType) EncodeNBT(e world.Entity) map[string]any {
 	ep := e.(*Ent)
 	return map[string]any{
-		"Pos":    nbtconv.Vec3ToFloat32Slice(ep.Position()),
-		"Motion": nbtconv.Vec3ToFloat32Slice(ep.Velocity()),
+		"UniqueID": ep.uniqueID,
+		"Pos":      nbtconv.Vec3ToFloat32Slice(ep.Position()),
+		"Motion":   nbtconv.Vec3ToFloat32Slice(ep.Velocity()),
 	}
 }

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -1,13 +1,15 @@
 package entity
 
 import (
+	"math/rand"
+	"sync"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/item/potion"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"sync"
-	"time"
 )
 
 // Behaviour implements the behaviour of an Ent.
@@ -25,15 +27,16 @@ type Config struct {
 
 // New creates a new Ent using conf. The entity has a type and a position.
 func (conf Config) New(t world.EntityType, pos mgl64.Vec3) *Ent {
-	return &Ent{t: t, pos: pos, conf: conf}
+	return &Ent{t: t, pos: pos, conf: conf, uniqueID: rand.Int63()}
 }
 
 // Ent is a world.Entity implementation that allows entity implementations to
 // share a lot of code. It is currently under development and is prone to
 // (breaking) changes.
 type Ent struct {
-	conf Config
-	t    world.EntityType
+	uniqueID int64
+	conf     Config
+	t        world.EntityType
 
 	mu  sync.Mutex
 	pos mgl64.Vec3

--- a/server/entity/firework.go
+++ b/server/entity/firework.go
@@ -1,6 +1,9 @@
 package entity
 
 import (
+	"math"
+	"math/rand"
+
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/cube/trace"
 	"github.com/df-mc/dragonfly/server/internal/nbtconv"
@@ -8,8 +11,6 @@ import (
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/sound"
 	"github.com/go-gl/mathgl/mgl64"
-	"math"
-	"math/rand"
 )
 
 // Firework is an item (and entity) used for creating decorative explosions, boosting when flying with elytra, and
@@ -17,6 +18,7 @@ import (
 type Firework struct {
 	transform
 
+	uniqueID   int64
 	yaw, pitch float64
 	firework   item.Firework
 
@@ -164,6 +166,9 @@ func (FireworkType) DecodeNBT(m map[string]any) world.Entity {
 		nbtconv.MapItem(m, "Item").Item().(item.Firework),
 	)
 	f.vel = nbtconv.Vec3(m, "Motion")
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		f.uniqueID = uniqueID
+	}
 	return f
 }
 
@@ -171,10 +176,11 @@ func (FireworkType) EncodeNBT(e world.Entity) map[string]any {
 	f := e.(*Firework)
 	yaw, pitch := f.Rotation().Elem()
 	return map[string]any{
-		"Item":   nbtconv.WriteItem(item.NewStack(f.Firework(), 1), true),
-		"Pos":    nbtconv.Vec3ToFloat32Slice(f.Position()),
-		"Motion": nbtconv.Vec3ToFloat32Slice(f.Velocity()),
-		"Yaw":    float32(yaw),
-		"Pitch":  float32(pitch),
+		"UniqueID": f.uniqueID,
+		"Item":     nbtconv.WriteItem(item.NewStack(f.Firework(), 1), true),
+		"Pos":      nbtconv.Vec3ToFloat32Slice(f.Position()),
+		"Motion":   nbtconv.Vec3ToFloat32Slice(f.Velocity()),
+		"Yaw":      float32(yaw),
+		"Pitch":    float32(pitch),
 	}
 }

--- a/server/entity/lingering_potion.go
+++ b/server/entity/lingering_potion.go
@@ -37,12 +37,16 @@ func (LingeringPotionType) BBox(world.Entity) cube.BBox {
 func (LingeringPotionType) DecodeNBT(m map[string]any) world.Entity {
 	pot := NewLingeringPotion(nbtconv.Vec3(m, "Pos"), nil, potion.From(nbtconv.Int32(m, "PotionId")))
 	pot.vel = nbtconv.Vec3(m, "Motion")
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		pot.uniqueID = uniqueID
+	}
 	return pot
 }
 
 func (LingeringPotionType) EncodeNBT(e world.Entity) map[string]any {
 	pot := e.(*Ent)
 	return map[string]any{
+		"UniqueID": pot.uniqueID,
 		"Pos":      nbtconv.Vec3ToFloat32Slice(pot.Position()),
 		"Motion":   nbtconv.Vec3ToFloat32Slice(pot.Velocity()),
 		"PotionId": int32(pot.conf.Behaviour.(*ProjectileBehaviour).conf.Potion.Uint8()),

--- a/server/entity/snowball.go
+++ b/server/entity/snowball.go
@@ -31,13 +31,17 @@ func (SnowballType) BBox(world.Entity) cube.BBox {
 func (SnowballType) DecodeNBT(m map[string]any) world.Entity {
 	s := NewSnowball(nbtconv.Vec3(m, "Pos"), nil)
 	s.vel = nbtconv.Vec3(m, "Motion")
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		s.uniqueID = uniqueID
+	}
 	return s
 }
 
 func (SnowballType) EncodeNBT(e world.Entity) map[string]any {
 	s := e.(*Ent)
 	return map[string]any{
-		"Pos":    nbtconv.Vec3ToFloat32Slice(s.Position()),
-		"Motion": nbtconv.Vec3ToFloat32Slice(s.Velocity()),
+		"UniqueID": s.uniqueID,
+		"Pos":      nbtconv.Vec3ToFloat32Slice(s.Position()),
+		"Motion":   nbtconv.Vec3ToFloat32Slice(s.Velocity()),
 	}
 }

--- a/server/entity/splash_potion.go
+++ b/server/entity/splash_potion.go
@@ -42,12 +42,16 @@ func (SplashPotionType) BBox(world.Entity) cube.BBox {
 func (SplashPotionType) DecodeNBT(m map[string]any) world.Entity {
 	pot := NewSplashPotion(nbtconv.Vec3(m, "Pos"), nil, potion.From(nbtconv.Int32(m, "PotionId")))
 	pot.vel = nbtconv.Vec3(m, "Motion")
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		pot.uniqueID = uniqueID
+	}
 	return pot
 }
 
 func (SplashPotionType) EncodeNBT(e world.Entity) map[string]any {
 	pot := e.(*Ent)
 	return map[string]any{
+		"UniqueID": pot.uniqueID,
 		"Pos":      nbtconv.Vec3ToFloat32Slice(pot.Position()),
 		"Motion":   nbtconv.Vec3ToFloat32Slice(pot.Velocity()),
 		"PotionId": int32(pot.conf.Behaviour.(*ProjectileBehaviour).conf.Potion.Uint8()),

--- a/server/entity/text.go
+++ b/server/entity/text.go
@@ -24,13 +24,18 @@ func (TextType) BBox(world.Entity) cube.BBox { return cube.BBox{} }
 func (TextType) NetworkEncodeEntity() string { return "minecraft:falling_block" }
 
 func (TextType) DecodeNBT(m map[string]any) world.Entity {
-	return NewText(nbtconv.String(m, "Text"), nbtconv.Vec3(m, "Pos"))
+	t := NewText(nbtconv.String(m, "Text"), nbtconv.Vec3(m, "Pos"))
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		t.uniqueID = uniqueID
+	}
+	return t
 }
 
 func (TextType) EncodeNBT(e world.Entity) map[string]any {
 	t := e.(*Ent)
 	return map[string]any{
-		"Pos":  nbtconv.Vec3ToFloat32Slice(t.Position()),
-		"Text": t.NameTag(),
+		"UniqueID": t.uniqueID,
+		"Pos":      nbtconv.Vec3ToFloat32Slice(t.Position()),
+		"Text":     t.NameTag(),
 	}
 }

--- a/server/entity/tnt.go
+++ b/server/entity/tnt.go
@@ -1,21 +1,23 @@
 package entity
 
 import (
+	"math"
+	"math/rand"
+	"time"
+
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/internal/nbtconv"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math"
-	"math/rand"
-	"time"
 )
 
 // TNT represents a primed TNT entity.
 type TNT struct {
 	transform
 
-	fuse int64
+	uniqueID int64
+	fuse     int64
 
 	c *MovementComputer
 }
@@ -23,7 +25,8 @@ type TNT struct {
 // NewTNT creates a new prime TNT instance.
 func NewTNT(pos mgl64.Vec3, fuse time.Duration) *TNT {
 	t := &TNT{
-		fuse: fuse.Milliseconds() / 50,
+		uniqueID: rand.Int63(),
+		fuse:     fuse.Milliseconds() / 50,
 		c: &MovementComputer{
 			Gravity:           0.04,
 			Drag:              0.02,
@@ -98,14 +101,18 @@ func (TNTType) BBox(world.Entity) cube.BBox {
 func (TNTType) DecodeNBT(m map[string]any) world.Entity {
 	tnt := NewTNT(nbtconv.Vec3(m, "Pos"), nbtconv.TickDuration[uint8](m, "Fuse"))
 	tnt.vel = nbtconv.Vec3(m, "Motion")
+	if uniqueID, ok := m["UniqueID"].(int64); ok {
+		tnt.uniqueID = uniqueID
+	}
 	return tnt
 }
 
 func (TNTType) EncodeNBT(e world.Entity) map[string]any {
 	t := e.(*TNT)
 	return map[string]any{
-		"Pos":    nbtconv.Vec3ToFloat32Slice(t.Position()),
-		"Motion": nbtconv.Vec3ToFloat32Slice(t.Velocity()),
-		"Fuse":   uint8(t.Fuse().Milliseconds() / 50),
+		"UniqueID": t.uniqueID,
+		"Pos":      nbtconv.Vec3ToFloat32Slice(t.Position()),
+		"Motion":   nbtconv.Vec3ToFloat32Slice(t.Velocity()),
+		"Fuse":     uint8(t.Fuse().Milliseconds() / 50),
 	}
 }

--- a/server/world/mcdb/provider.go
+++ b/server/world/mcdb/provider.go
@@ -500,7 +500,6 @@ func (p *Provider) SaveEntities(pos world.ChunkPos, entities []world.Entity, dim
 		enc := nbt.NewEncoderWithEncoding(buf, nbt.LittleEndian)
 		t, ok := e.Type().(world.SaveableEntityType)
 		if !ok {
-			fmt.Printf("Cant Save Entity %s", e.Type().EncodeEntity())
 			continue
 		}
 		x := t.EncodeNBT(e)

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -1336,7 +1336,7 @@ func (w *World) loadIntoBlocks(c *chunkData, blockEntityData []map[string]any) {
 func (w *World) saveChunk(pos ChunkPos, c *chunkData) {
 	c.Lock()
 	if !w.conf.ReadOnly {
-		if len(c.e) > 0 || c.m {
+		if len(c.e) > 0 || c.m || len(c.entities) > 0 {
 			c.Compact()
 			if err := w.provider().SaveChunk(pos, c.Chunk, w.conf.Dim); err != nil {
 				w.conf.Log.Errorf("error saving chunk %v to provider: %v", pos, err)


### PR DESCRIPTION
implementing https://learn.microsoft.com/en-us/minecraft/creator/documents/actorstorage
this is how the game stores entities so now entities saved from dragonfly show up when the world is loaded in single player
and entities in worlds from singleplayer show up in dragonfly.
also checks for the old keyEntities based entity data for loading older worlds, i couldnt test that since i dont have an older world but it should work.