### PR TITLE
fix enderchest facing direction not being decoded

### DIFF
--- a/server/block/ender_chest.go
+++ b/server/block/ender_chest.go
@@ -113,10 +113,6 @@ func (c EnderChest) EncodeNBT() map[string]interface{} {
 
 // DecodeNBT ...
 func (c EnderChest) DecodeNBT(map[string]interface{}) interface{} {
-	facing := c.Facing
-	//noinspection GoAssignmentToReceiver
-	c = NewEnderChest()
-	c.Facing = facing
 	return c
 }
 

--- a/server/block/ender_chest.go
+++ b/server/block/ender_chest.go
@@ -113,7 +113,11 @@ func (c EnderChest) EncodeNBT() map[string]interface{} {
 
 // DecodeNBT ...
 func (c EnderChest) DecodeNBT(map[string]interface{}) interface{} {
-	return NewEnderChest()
+	facing := c.Facing
+	//noinspection GoAssignmentToReceiver
+	c = NewEnderChest()
+	c.Facing = facing
+	return c
 }
 
 // EncodeItem ...


### PR DESCRIPTION
Discovered this creating a structure, on paste, all the enderchest were facing in the same direction, this fixed it.