### PR TITLE
Removed the splash and lingering potion entity glint

### DIFF
--- a/server/entity/lingering_potion.go
+++ b/server/entity/lingering_potion.go
@@ -29,7 +29,6 @@ type LingeringPotionType struct{}
 func (LingeringPotionType) EncodeEntity() string {
 	return "minecraft:lingering_potion"
 }
-func (LingeringPotionType) Glint() bool { return true }
 func (LingeringPotionType) BBox(world.Entity) cube.BBox {
 	return cube.Box(-0.125, 0, -0.125, 0.125, 0.25, 0.125)
 }

--- a/server/entity/splash_potion.go
+++ b/server/entity/splash_potion.go
@@ -34,7 +34,6 @@ var splashPotionConf = ProjectileBehaviourConfig{
 type SplashPotionType struct{}
 
 func (SplashPotionType) EncodeEntity() string { return "minecraft:splash_potion" }
-func (SplashPotionType) Glint() bool          { return true }
 func (SplashPotionType) BBox(world.Entity) cube.BBox {
 	return cube.Box(-0.125, 0, -0.125, 0.125, 0.25, 0.125)
 }


### PR DESCRIPTION
Since potion-related(splash and lingering) items don't have a glint in the current version of the game, entities shouldn't have one either