### PR TITLE
Feature/reset food saturation

### DIFF
--- a/server/player/hunger.go
+++ b/server/player/hunger.go
@@ -66,7 +66,7 @@ func (m *hungerManager) Reset() {
 }
 
 // ResetExhaustion resets the exhaustion level of the player to 0.
-// Prevents the player food level decrease after non cancelling the food loss
+// Prevents the player's food level from decreasing after preventing food loss.
 func (m *hungerManager) resetExhaustion() {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/server/player/hunger.go
+++ b/server/player/hunger.go
@@ -65,6 +65,14 @@ func (m *hungerManager) Reset() {
 	m.mu.Unlock()
 }
 
+// ResetExhaustion resets the exhaustion level of the player to 0.
+// Prevents the player food level decrease after non cancelling the food loss
+func (m *hungerManager) ResetExhaustion() {
+	m.exhaustionLevel = 0
+	m.saturationLevel = 0
+	m.foodTick = 0
+}
+
 // exhaust exhausts the player by the amount of points passed. If the total exhaustion level exceeds 4, a
 // saturation point, or food point, if saturation is 0, will be subtracted.
 func (m *hungerManager) exhaust(points float64) {

--- a/server/player/hunger.go
+++ b/server/player/hunger.go
@@ -65,7 +65,7 @@ func (m *hungerManager) Reset() {
 	m.mu.Unlock()
 }
 
-// ResetExhaustion resets the exhaustion level of the player to 0.
+// ResetExhaustion resets the player's exhaustion level to 0.
 // Prevents the player's food level from decreasing after preventing food loss.
 func (m *hungerManager) resetExhaustion() {
 	m.mu.Lock()

--- a/server/player/hunger.go
+++ b/server/player/hunger.go
@@ -68,6 +68,8 @@ func (m *hungerManager) Reset() {
 // ResetExhaustion resets the exhaustion level of the player to 0.
 // Prevents the player food level decrease after non cancelling the food loss
 func (m *hungerManager) resetExhaustion() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.exhaustionLevel = 0
 	m.saturationLevel = 0
 	m.foodTick = 0

--- a/server/player/hunger.go
+++ b/server/player/hunger.go
@@ -67,7 +67,7 @@ func (m *hungerManager) Reset() {
 
 // ResetExhaustion resets the exhaustion level of the player to 0.
 // Prevents the player food level decrease after non cancelling the food loss
-func (m *hungerManager) ResetExhaustion() {
+func (m *hungerManager) resetExhaustion() {
 	m.exhaustionLevel = 0
 	m.saturationLevel = 0
 	m.foodTick = 0

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -818,6 +818,12 @@ func (p *Player) Exhaust(points float64) {
 
 		ctx := event.C()
 		if p.Handler().HandleFoodLoss(ctx, before, &after); ctx.Cancelled() {
+			// Reset the exhaustion level if the event was cancelled.
+			// Because if we cancel this on some moments, and after a time we don't cancel it,
+			// the first food level going to decrease a bit faster than expected.
+			// An example is if we cancelled that on a world, and we change of world, our food decrease very fast on the next tick
+			p.hunger.ResetExhaustion()
+
 			return
 		}
 		p.hunger.SetFood(after)

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -822,7 +822,7 @@ func (p *Player) Exhaust(points float64) {
 			// Because if we cancel this on some moments, and after a time we don't cancel it,
 			// the first food level going to decrease a bit faster than expected.
 			// An example is if we cancelled that on a world, and we change of world, our food decrease very fast on the next tick
-			p.hunger.ResetExhaustion()
+			p.hunger.resetExhaustion()
 
 			return
 		}


### PR DESCRIPTION
Add reset the exhaustion and saturation when the Food Loss handler is cancelled. This help to prevent loss very fast the food after no longer cancelling that handler.

Example

https://github.com/user-attachments/assets/ab8d9917-2c1e-4568-9b98-7da8e6bbb1d2

