### PR TITLE
Implemented a new way of displaying the mob effects.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/rogpeppe/go-internal v1.11.0
-	github.com/sandertv/gophertunnel v1.39.0
+	github.com/sandertv/gophertunnel v1.39.2
 	github.com/segmentio/fasthash v1.0.3
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/rogpeppe/go-internal v1.11.0
-	github.com/sandertv/gophertunnel v1.39.2
+	github.com/sandertv/gophertunnel v1.39.3
 	github.com/segmentio/fasthash v1.0.3
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/sandertv/go-raknet v1.14.1 h1:V2Gslo+0x4jfj+p0PM48mWxmMbYkxSlgeKy//y3ZrzI=
 github.com/sandertv/go-raknet v1.14.1/go.mod h1:/yysjwfCXm2+2OY8mBazLzcxJ3irnylKCyG3FLgUPVU=
-github.com/sandertv/gophertunnel v1.39.0 h1:Am2NhSQjxscAVihRG/Qz7cfyJJp91RIl/5DpSLbwXp0=
-github.com/sandertv/gophertunnel v1.39.0/go.mod h1:uSaX7RbVaCcxsGAx2vyZnkT0M6kZFGCdAqLn0+wuKyY=
+github.com/sandertv/gophertunnel v1.39.2 h1:h5sGT53GcsK8b9RprtGJSEvH5vAJ1CGGAAW+4bTrDkU=
+github.com/sandertv/gophertunnel v1.39.2/go.mod h1:uSaX7RbVaCcxsGAx2vyZnkT0M6kZFGCdAqLn0+wuKyY=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/sandertv/go-raknet v1.14.1 h1:V2Gslo+0x4jfj+p0PM48mWxmMbYkxSlgeKy//y3ZrzI=
 github.com/sandertv/go-raknet v1.14.1/go.mod h1:/yysjwfCXm2+2OY8mBazLzcxJ3irnylKCyG3FLgUPVU=
-github.com/sandertv/gophertunnel v1.39.2 h1:h5sGT53GcsK8b9RprtGJSEvH5vAJ1CGGAAW+4bTrDkU=
-github.com/sandertv/gophertunnel v1.39.2/go.mod h1:uSaX7RbVaCcxsGAx2vyZnkT0M6kZFGCdAqLn0+wuKyY=
+github.com/sandertv/gophertunnel v1.39.3 h1:oc0PPOhrB9utScy8SEYJTWQIFexzf8CVizmB5MLsb6A=
+github.com/sandertv/gophertunnel v1.39.3/go.mod h1:uSaX7RbVaCcxsGAx2vyZnkT0M6kZFGCdAqLn0+wuKyY=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=

--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -153,7 +153,7 @@ func (s *Session) addSpecificMetadata(e any, m protocol.EntityMetadata) {
 				packedEffects = (packedEffects << (i * 7)) | int64(id<<1)
 			}
 		}
-		m[131] = packedEffects // TODO: This should be protocol.EntityDataKeyVisibleMobEffects.
+		m[protocol.EntityDataKeyVisibleMobEffects] = packedEffects
 	}
 	if v, ok := e.(variable); ok {
 		m[protocol.EntityDataKeyVariant] = v.Variant()

--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -141,7 +141,7 @@ func (s *Session) addSpecificMetadata(e any, m protocol.EntityMetadata) {
 			m[protocol.EntityDataKeyCustomDisplay] = tip + 1
 		}
 	}
-	if eff, ok := e.(effectBearer); ok && len(eff.Effects()) > 0 {
+	if eff, ok := e.(effectBearer); ok {
 		var packedEffects int64
 
 		for i, ef := range eff.Effects() {


### PR DESCRIPTION
With the new version 1.21, mob effect bubbles are no longer int32-packed RGBA. Now it is an array of bytes up to 8 elements packed in int64.

Before: https://youtu.be/k1qiewknQwQ
After: https://youtu.be/YI8ETqjhow0

https://github.com/sandertv/gophertunnel must be updated with the new entity metadata key.