### PR TITLE
block/ladder.go: Change Direction to Face to allow states 0 and 1

### DIFF
--- a/server/block/ladder.go
+++ b/server/block/ladder.go
@@ -17,12 +17,12 @@ type Ladder struct {
 	sourceWaterDisplacer
 
 	// Facing is the side of the block the ladder is currently attached to.
-	Facing cube.Direction
+	Facing cube.Face
 }
 
 // NeighbourUpdateTick ...
 func (l Ladder) NeighbourUpdateTick(pos, _ cube.Pos, w *world.World) {
-	if _, ok := w.Block(pos.Side(l.Facing.Opposite().Face())).(LightDiffuser); ok {
+	if _, ok := w.Block(pos.Side(l.Facing.Opposite())).(LightDiffuser); ok {
 		w.SetBlock(pos, nil, nil)
 		w.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: l})
 		dropItem(w, item.NewStack(l, 1), pos.Vec3Centre())
@@ -51,7 +51,7 @@ func (l Ladder) UseOnBlock(pos cube.Pos, face cube.Face, _ mgl64.Vec3, w *world.
 			return false
 		}
 	}
-	l.Facing = face.Direction()
+	l.Facing = face
 
 	place(w, pos, l, user, ctx)
 	return placed(ctx)
@@ -86,17 +86,17 @@ func (l Ladder) EncodeItem() (name string, meta int16) {
 
 // EncodeBlock ...
 func (l Ladder) EncodeBlock() (string, map[string]any) {
-	return "minecraft:ladder", map[string]any{"facing_direction": int32(l.Facing + 2)}
+	return "minecraft:ladder", map[string]any{"facing_direction": int32(l.Facing)}
 }
 
 // Model ...
 func (l Ladder) Model() world.BlockModel {
-	return model.Ladder{Facing: l.Facing}
+	return model.Ladder{Facing: cube.Direction(l.Facing)}
 }
 
 // allLadders ...
 func allLadders() (b []world.Block) {
-	for i := cube.Direction(0); i <= 3; i++ {
+	for i := cube.Face(0); i <= 5; i++ {
 		b = append(b, Ladder{Facing: i})
 	}
 	return

--- a/server/block/ladder.go
+++ b/server/block/ladder.go
@@ -16,7 +16,8 @@ type Ladder struct {
 	transparent
 	sourceWaterDisplacer
 
-	// Facing is the side of the block the ladder is currently attached to. It shouldn't be either FaceDown or FaceUp
+	// Facing is the side of the block the ladder is currently attached to. cube.FaceDown and cube.FaceUp
+	// do not do anything in game but they are still valid states.
 	Facing cube.Face
 }
 
@@ -91,7 +92,7 @@ func (l Ladder) EncodeBlock() (string, map[string]any) {
 
 // Model ...
 func (l Ladder) Model() world.BlockModel {
-	return model.Ladder{Facing: cube.Direction(l.Facing)}
+	return model.Ladder{Facing: l.Facing}
 }
 
 // allLadders ...

--- a/server/block/ladder.go
+++ b/server/block/ladder.go
@@ -16,7 +16,7 @@ type Ladder struct {
 	transparent
 	sourceWaterDisplacer
 
-	// Facing is the side of the block the ladder is currently attached to.
+	// Facing is the side of the block the ladder is currently attached to. It shouldn't be either FaceDown or FaceUp
 	Facing cube.Face
 }
 
@@ -96,8 +96,8 @@ func (l Ladder) Model() world.BlockModel {
 
 // allLadders ...
 func allLadders() (b []world.Block) {
-	for i := cube.Face(0); i <= 5; i++ {
-		b = append(b, Ladder{Facing: i})
+	for _, f := range cube.Faces() {
+		b = append(b, Ladder{Facing: f})
 	}
 	return
 }

--- a/server/block/model/ladder.go
+++ b/server/block/model/ladder.go
@@ -8,12 +8,12 @@ import (
 // Ladder is the model for a ladder block.
 type Ladder struct {
 	// Facing is the side opposite to the block the Ladder is currently attached to.
-	Facing cube.Direction
+	Facing cube.Face
 }
 
 // BBox returns one physics.BBox that depends on the facing direction of the Ladder.
 func (l Ladder) BBox(cube.Pos, *world.World) []cube.BBox {
-	return []cube.BBox{full.ExtendTowards(l.Facing.Face(), -0.8125)}
+	return []cube.BBox{full.ExtendTowards(l.Facing, -0.8125)}
 }
 
 // FaceSolid always returns false.


### PR DESCRIPTION
Fixed a bug where ladder wasn't being added to creative inventory. It was happening due to ladder in dragonfly not allowing facing_direction to be 0 and 1. We already discussed this in Discord:
![image](https://github.com/user-attachments/assets/a2b8b800-505a-4241-82b9-75a6f678585d)
