### PR TITLE
entity_metadata.go: Fix incorrectly enconding of packedEffects

### DIFF
--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -150,7 +150,7 @@ func (s *Session) addSpecificMetadata(e any, m protocol.EntityMetadata) {
 				if !found {
 					continue
 				}
-				packedEffects = (packedEffects << 7) | int64(id << 1)
+				packedEffects = (packedEffects << 7) | int64(id<<1)
 				if ef.Ambient() {
 					packedEffects |= 1
 				}

--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -144,13 +144,16 @@ func (s *Session) addSpecificMetadata(e any, m protocol.EntityMetadata) {
 	if eff, ok := e.(effectBearer); ok {
 		var packedEffects int64
 
-		for i, ef := range eff.Effects() {
+		for _, ef := range eff.Effects() {
 			if !ef.ParticlesHidden() {
 				id, found := effect.ID(ef.Type())
 				if !found {
 					continue
 				}
-				packedEffects = (packedEffects << (i * 7)) | int64(id<<1)
+				packedEffects = (packedEffects << 7) | int64(id << 1)
+				if ef.Ambient() {
+					packedEffects |= 1
+				}
 			}
 		}
 		m[protocol.EntityDataKeyVisibleMobEffects] = packedEffects


### PR DESCRIPTION
The implementation has the following problems:
- Does not include ambient indicator
- Only the first two effects are correctly packed
  - This is caused because for some reason you are multiplying the shift 7 by the index. (wtf??).
    -  On the first iteration nothing happened because it gave a bit shift of 0, as it is the first iteration it does not matter if there is bit shift or not.
    - On the second iteration 7 * 1, the shift is correct, Ok
    - From the third iteration on, the shifts are incorrect.
  
`I almost had a stroke with the go syntax`