### PR TITLE
Fixed hopper insert behaviour in composter

### DIFF
--- a/server/block/composter.go
+++ b/server/block/composter.go
@@ -24,7 +24,7 @@ type Composter struct {
 
 // InsertItem ...
 func (c Composter) InsertItem(h Hopper, pos cube.Pos, w *world.World) bool {
-	if c.Level == 8 {
+	if c.Level >= 7 {
 		return false
 	}
 

--- a/server/block/composter.go
+++ b/server/block/composter.go
@@ -24,7 +24,7 @@ type Composter struct {
 
 // InsertItem ...
 func (c Composter) InsertItem(h Hopper, pos cube.Pos, w *world.World) bool {
-	if c.Level >= 7 {
+	if c.Level >= 7 || h.Facing != cube.FaceDown {
 		return false
 	}
 


### PR DESCRIPTION
In vanilla, hopper can insert item in composter only if it's level is less than 7