### PR TITLE
session: fix packet handling race condition

### DIFF
--- a/server/session/session.go
+++ b/server/session/session.go
@@ -313,15 +313,23 @@ func (s *Session) handlePackets() {
 		_ = s.Close()
 	}()
 	for {
-		pk, err := s.conn.ReadPacket()
-		if err != nil {
-			return
-		}
-		if err := s.handlePacket(pk); err != nil {
-			// An error occurred during the handling of a packet. Print the error and stop handling any more
-			// packets.
-			s.log.Debugf("failed processing packet from %v (%v): %v\n", s.conn.RemoteAddr(), s.c.Name(), err)
-			return
+		s.c.World().Wait()
+
+		for {
+			pk, err := s.conn.ReadPacket()
+			if err != nil {
+				return
+			}
+			if pk == nil {
+				break
+			}
+
+			if err := s.handlePacket(pk); err != nil {
+				// An error occurred during the handling of a packet. Print the error and stop handling any more
+				// packets.
+				s.log.Debugf("failed processing packet from %v (%v): %v\n", s.conn.RemoteAddr(), s.c.Name(), err)
+				return
+			}
 		}
 	}
 }

--- a/server/world/conf.go
+++ b/server/world/conf.go
@@ -4,6 +4,7 @@ import (
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/sirupsen/logrus"
 	"math/rand"
+	"sync"
 	"time"
 )
 
@@ -80,6 +81,7 @@ func (conf Config) New() *World {
 		conf:             conf,
 		ra:               conf.Dim.Range(),
 		set:              s,
+		cond:             *sync.NewCond(&sync.Mutex{}),
 	}
 	w.weather, w.ticker = weather{w: w}, ticker{w: w}
 	var h Handler = NopHandler{}

--- a/server/world/tick.go
+++ b/server/world/tick.go
@@ -23,6 +23,8 @@ func (t ticker) tickLoop() {
 	for {
 		select {
 		case <-tc.C:
+			t.w.cond.Broadcast()
+
 			t.tick()
 		case <-t.w.closing:
 			// World is being closed: Stop ticking and get rid of a task.


### PR DESCRIPTION
Closes #919

All sessions when processing a packet wait for the tick in the world the Controllable is in, this is when packet processing occurs in the session