### PR TITLE
Documentation correction: Toggles dont contain text as far as I know

### DIFF
--- a/server/player/form/element.go
+++ b/server/player/form/element.go
@@ -72,8 +72,7 @@ func (i Input) Value() string {
 type Toggle struct {
 	// Text is the text displayed over the toggle element. The text may contain Minecraft formatting codes.
 	Text string
-	// Default is the default value filled out in the input. The user may remove this value and fill out its
-	// own text. The text may contain Minecraft formatting codes.
+	// Default determines if the toggle should be on/off by default.
 	Default bool
 
 	value bool


### PR DESCRIPTION
> // Default is the default value filled out in the input. The user may remove this value and fill out its
	// own text. The text may contain Minecraft formatting codes.

This was likely copied over from the Input's default field.

I discovered this while reading df's form implementation to help implement and especially document my own in Rust. (Thanks for all the comments in both df and gophertunnel, they are really helpful and I did not copy the comments 1:1 for the record)

This is a giant pr, so be warned!