### PR TITLE
player/player.go: add empty string check in command resolution.

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -330,10 +330,17 @@ func (p *Player) ExecuteCommand(commandLine string) {
 		return
 	}
 	args := strings.Split(commandLine, " ")
-	command, ok := cmd.ByAlias(args[0][1:])
+
+	name := args[0]
+	if name == "" {
+		return
+	}
+	name = name[1:]
+	
+	command, ok := cmd.ByAlias(name)
 	if !ok {
 		o := &cmd.Output{}
-		o.Errort(cmd.MessageUnknown, args[0])
+		o.Errort(cmd.MessageUnknown, name)
 		p.SendCommandOutput(o)
 		return
 	}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -331,12 +331,11 @@ func (p *Player) ExecuteCommand(commandLine string) {
 	}
 	args := strings.Split(commandLine, " ")
 
-	name := args[0]
-	if name == "" {
+	name, ok := strings.CutPrefix(args[0], "/")
+	if !ok {
 		return
 	}
-	name = name[1:]
-	
+
 	command, ok := cmd.ByAlias(name)
 	if !ok {
 		o := &cmd.Output{}


### PR DESCRIPTION
If the client send an empty CommandRequest:
```go
_ = serverConn.WritePacket(&packet.CommandRequest{})
```

Then the server will get the following panic:
```
panic: runtime error: slice bounds out of range [1:0]

goroutine 13 [running]:
github.com/df-mc/dragonfly/server/player.(*Player).ExecuteCommand(0xc001302080, {0x14a7660?, 0x46ad1a?})
        /mnt/data/projects/go/dragonfly/server/player/player.go:333 +0x587
github.com/df-mc/dragonfly/server/session.(*CommandRequestHandler).Handle(0xa37320?, {0xc3bc70?, 0xc0015509b0?}, 0xc000e20e10?, 0xc00238fd78?, {0xc53640?, 0xc001302080?})
        /mnt/data/projects/go/dragonfly/server/session/handler_command_request.go:23 +0xaf
github.com/df-mc/dragonfly/server/session.(*Session).handlePacket(0xc00276a008, {0xc3bc70, 0xc0015509b0}, 0xc002996100, {0xc53640, 0xc001302080})
        /mnt/data/projects/go/dragonfly/server/session/session.go:454 +0xc3
github.com/df-mc/dragonfly/server/session.(*Session).handlePackets.func2(0xc002996100?, {0xc421e0?, 0xc001302080?})
        /mnt/data/projects/go/dragonfly/server/session/session.go:319 +0xd0
github.com/df-mc/dragonfly/server/world.(*EntityHandle).execWorld.func1(0xc002996100)
        /mnt/data/projects/go/dragonfly/server/world/entity.go:192 +0x44
github.com/df-mc/dragonfly/server/world.weakTransaction.Run({0xc0000c9500?, 0xc0014180c0?, 0xc0001e8530?, 0xc0022fae00?}, 0xc00146e900)
        /mnt/data/projects/go/dragonfly/server/world/tx.go:264 +0x9a
github.com/df-mc/dragonfly/server/world.(*World).handleTransactions(0xc00146e900)
        /mnt/data/projects/go/dragonfly/server/world/world.go:131 +0x2e
created by github.com/df-mc/dragonfly/server/world.Config.New in goroutine 1
        /mnt/data/projects/go/dragonfly/server/world/conf.go:108 +0x565

Process finished with the exit code 2

```

This PR addresses it

Also, this PR makes the vanilla output of the unknown command, without the "/" prefix