### PR TITLE
Spectator Mode use GameTypeSurvivalSpectator

### DIFF
--- a/server/session/player.go
+++ b/server/session/player.go
@@ -901,7 +901,7 @@ func gameTypeFromMode(mode world.GameMode) int32 {
 		return packet.GameTypeCreative
 	}
 	if !mode.Visible() && !mode.HasCollision() {
-		return packet.GameTypeSpectator
+		return packet.GameTypeSurvivalSpectator
 	}
 	return packet.GameTypeSurvival
 }


### PR DESCRIPTION
- It allows showing hotbar, opening menus, etc. 
Servers usually allow players to use an item in spectator mode. For example, players might want to use a compass item to teleport. This is not possible when the hotbar is not visible.

- It's possible to hide the hotbar via SetHudPacket, but it won't be implemented in this PR.