### PR TITLE
player.HideEntity checks EntityHandle, prevent the player from hiding itself

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2312,7 +2312,7 @@ func (p *Player) OpenBlockContainer(pos cube.Pos, tx *world.Tx) {
 // HideEntity hides a world.Entity from the Player so that it can under no circumstance see it. Hidden entities can be
 // made visible again through a call to ShowEntity.
 func (p *Player) HideEntity(e world.Entity) {
-	if p.session() != session.Nop && p != e {
+	if p.session() != session.Nop && p.H() != e.H() {
 		p.session().StopShowingEntity(e)
 	}
 }


### PR DESCRIPTION
* [`server/player/player.go`](diffhunk://#diff-826d2b8b93662b774ba65460276a04857b96d6e04bf4c95d12958b42f1189ff9L2315-R2315): Modified the `HideEntity` method to compare the unique identifiers of the player and the entity to prevent the player from hiding itself.