### PR TITLE
Added infinite duration effects

### DIFF
--- a/server/entity/effect.go
+++ b/server/entity/effect.go
@@ -49,7 +49,8 @@ func (m *EffectManager) Add(e effect.Effect, entity Living) effect.Effect {
 		t.Start(entity, lvl)
 		return e
 	}
-	if existing.Level() > lvl || (existing.Level() == lvl && existing.Duration() > dur) {
+	// Infinite duration has priority over other durations
+	if existing.Level() > lvl || (existing.Level() == lvl && (existing.Duration() > dur || existing.Duration() == -1)) {
 		return existing
 	}
 	m.effects[typ] = e
@@ -92,7 +93,7 @@ func (m *EffectManager) Tick(entity Living, tx *world.Tx) {
 	m.initialEffects = nil
 
 	for i, eff := range m.effects {
-		if m.expired(eff) {
+		if m.expired(eff) && eff.Duration() != -1 {
 			delete(m.effects, i)
 			eff.Type().(effect.LastingType).End(entity, eff.Level())
 			update = true

--- a/server/entity/effect.go
+++ b/server/entity/effect.go
@@ -32,8 +32,8 @@ func (m *EffectManager) Add(e effect.Effect, entity Living) effect.Effect {
 	if lvl <= 0 {
 		panic(fmt.Sprintf("(*EffectManager).Add: effect cannot have level of 0 or below: %v", lvl))
 	}
-	if dur < 0 {
-		panic(fmt.Sprintf("(*EffectManager).Add: effect cannot have negative duration: %v", dur))
+	if dur < -1 {
+		panic(fmt.Sprintf("(*EffectManager).Add: effect cannot have negative duration other than -1 (infinite): %v", dur))
 	}
 	t, ok := e.Type().(effect.LastingType)
 	if !ok {

--- a/server/entity/effect.go
+++ b/server/entity/effect.go
@@ -32,7 +32,7 @@ func (m *EffectManager) Add(e effect.Effect, entity Living) effect.Effect {
 	if lvl <= 0 {
 		panic(fmt.Sprintf("(*EffectManager).Add: effect cannot have level of 0 or below: %v", lvl))
 	}
-	if dur < 0 && !e.Infinite() {
+	if dur < 0 {
 		panic(fmt.Sprintf("(*EffectManager).Add: effect cannot have negative duration: %v", dur))
 	}
 	t, ok := e.Type().(effect.LastingType)
@@ -50,7 +50,7 @@ func (m *EffectManager) Add(e effect.Effect, entity Living) effect.Effect {
 		return e
 	}
 	// Infinite duration has priority over other durations
-	if existing.Level() > lvl || (existing.Level() == lvl && (existing.Duration() > dur || e.Infinite())) {
+	if existing.Level() > lvl || (existing.Level() == lvl && ((existing.Duration() > dur && !e.Infinite()) || existing.Infinite())) {
 		return existing
 	}
 	m.effects[typ] = e

--- a/server/entity/effect.go
+++ b/server/entity/effect.go
@@ -93,7 +93,7 @@ func (m *EffectManager) Tick(entity Living, tx *world.Tx) {
 	m.initialEffects = nil
 
 	for i, eff := range m.effects {
-		if m.expired(eff) && eff.Duration() != -1 {
+		if m.expired(eff) {
 			delete(m.effects, i)
 			eff.Type().(effect.LastingType).End(entity, eff.Level())
 			update = true
@@ -112,5 +112,5 @@ func (m *EffectManager) Tick(entity Living, tx *world.Tx) {
 
 // expired checks if an Effect has expired.
 func (m *EffectManager) expired(e effect.Effect) bool {
-	return e.Duration() <= 0
+	return e.Duration() <= 0 && e.Duration() != -1
 }

--- a/server/entity/effect.go
+++ b/server/entity/effect.go
@@ -32,8 +32,8 @@ func (m *EffectManager) Add(e effect.Effect, entity Living) effect.Effect {
 	if lvl <= 0 {
 		panic(fmt.Sprintf("(*EffectManager).Add: effect cannot have level of 0 or below: %v", lvl))
 	}
-	if dur < -1 {
-		panic(fmt.Sprintf("(*EffectManager).Add: effect cannot have negative duration other than -1 (infinite): %v", dur))
+	if dur < 0 && !e.Infinite() {
+		panic(fmt.Sprintf("(*EffectManager).Add: effect cannot have negative duration: %v", dur))
 	}
 	t, ok := e.Type().(effect.LastingType)
 	if !ok {
@@ -50,7 +50,7 @@ func (m *EffectManager) Add(e effect.Effect, entity Living) effect.Effect {
 		return e
 	}
 	// Infinite duration has priority over other durations
-	if existing.Level() > lvl || (existing.Level() == lvl && (existing.Duration() > dur || existing.Duration() == -1)) {
+	if existing.Level() > lvl || (existing.Level() == lvl && (existing.Duration() > dur || e.Infinite())) {
 		return existing
 	}
 	m.effects[typ] = e
@@ -112,5 +112,5 @@ func (m *EffectManager) Tick(entity Living, tx *world.Tx) {
 
 // expired checks if an Effect has expired.
 func (m *EffectManager) expired(e effect.Effect) bool {
-	return e.Duration() <= 0 && e.Duration() != -1
+	return e.Duration() <= 0 && !e.Infinite()
 }

--- a/server/entity/effect/effect.go
+++ b/server/entity/effect/effect.go
@@ -37,6 +37,7 @@ type Effect struct {
 	lvl                      int
 	potency                  float64
 	ambient, particlesHidden bool
+	infinite                 bool
 	tick                     int
 }
 
@@ -68,6 +69,11 @@ func NewAmbient(t LastingType, lvl int, d time.Duration) Effect {
 	return Effect{t: t, lvl: lvl, d: d, ambient: true}
 }
 
+// NewInfinite creates a new infinitely lasting effect.
+func NewInfinite(t LastingType, lvl int) Effect {
+	return Effect{t: t, lvl: lvl, infinite: true}
+}
+
 // WithoutParticles returns the same Effect with particles disabled. Adding the effect to players will not display the
 // particles around the player.
 func (e Effect) WithoutParticles() Effect {
@@ -97,6 +103,11 @@ func (e Effect) Ambient() bool {
 	return e.ambient
 }
 
+// Infinite returns if the Effect duration is infinite.
+func (e Effect) Infinite() bool {
+	return e.infinite
+}
+
 // Type returns the underlying type of the Effect. It is either of the type Type or LastingType, depending on whether it
 // was created using New or NewAmbient, or NewInstant.
 func (e Effect) Type() Type {
@@ -107,7 +118,7 @@ func (e Effect) Type() Type {
 // Effect.
 func (e Effect) TickDuration() Effect {
 	if _, ok := e.t.(LastingType); ok {
-		if e.d != -1 {
+		if !e.Infinite() {
 			e.d -= time.Second / 20
 		}
 		e.tick++

--- a/server/entity/effect/effect.go
+++ b/server/entity/effect/effect.go
@@ -107,7 +107,9 @@ func (e Effect) Type() Type {
 // Effect.
 func (e Effect) TickDuration() Effect {
 	if _, ok := e.t.(LastingType); ok {
-		e.d -= time.Second / 20
+		if e.d != -1 {
+			e.d -= time.Second / 20
+		}
 		e.tick++
 	}
 	return e

--- a/server/player/playerdb/effect.go
+++ b/server/player/playerdb/effect.go
@@ -10,11 +10,12 @@ func effectsToData(effects []effect.Effect) []jsonEffect {
 			continue
 		}
 		data[key] = jsonEffect{
-			ID:       id,
-			Duration: eff.Duration(),
-			Level:    eff.Level(),
-			Ambient:  eff.Ambient(),
-			Infinite: eff.Infinite(),
+			ID:              id,
+			Duration:        eff.Duration(),
+			Level:           eff.Level(),
+			Ambient:         eff.Ambient(),
+			ParticlesHidden: eff.ParticlesHidden(),
+			Infinite:        eff.Infinite(),
 		}
 	}
 	return data
@@ -31,9 +32,15 @@ func dataToEffects(data []jsonEffect) []effect.Effect {
 		case effect.LastingType:
 			if d.Ambient {
 				effects[i] = effect.NewAmbient(eff, d.Level, d.Duration)
-				continue
+			} else if d.Infinite {
+				effects[i] = effect.NewInfinite(eff, d.Level)
+			} else {
+				effects[i] = effect.New(eff, d.Level, d.Duration)
 			}
-			effects[i] = effect.New(eff, d.Level, d.Duration)
+
+			if d.ParticlesHidden {
+				effects[i] = effects[i].WithoutParticles()
+			}
 		default:
 			effects[i] = effect.NewInstant(eff, d.Level)
 		}

--- a/server/player/playerdb/effect.go
+++ b/server/player/playerdb/effect.go
@@ -14,6 +14,7 @@ func effectsToData(effects []effect.Effect) []jsonEffect {
 			Duration: eff.Duration(),
 			Level:    eff.Level(),
 			Ambient:  eff.Ambient(),
+			Infinite: eff.Infinite(),
 		}
 	}
 	return data

--- a/server/player/playerdb/json.go
+++ b/server/player/playerdb/json.go
@@ -138,4 +138,5 @@ type jsonEffect struct {
 	Level    int
 	Duration time.Duration
 	Ambient  bool
+	Infinite bool
 }

--- a/server/player/playerdb/json.go
+++ b/server/player/playerdb/json.go
@@ -134,9 +134,10 @@ type jsonSlot struct {
 }
 
 type jsonEffect struct {
-	ID       int
-	Level    int
-	Duration time.Duration
-	Ambient  bool
-	Infinite bool
+	ID              int
+	Level           int
+	Duration        time.Duration
+	Ambient         bool
+	ParticlesHidden bool
+	Infinite        bool
 }

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -531,13 +531,18 @@ func (s *Session) SendHealth(health, max, absorption float64) {
 func (s *Session) SendEffect(e effect.Effect) {
 	s.SendEffectRemoval(e.Type())
 	id, _ := effect.ID(e.Type())
+	dur := e.Duration()
+	if dur != -1 {
+		dur = dur / (time.Second / 20)
+	}
+
 	s.writePacket(&packet.MobEffect{
 		EntityRuntimeID: selfEntityRuntimeID,
 		Operation:       packet.MobEffectAdd,
 		EffectType:      int32(id),
 		Amplifier:       int32(e.Level() - 1),
 		Particles:       !e.ParticlesHidden(),
-		Duration:        int32(e.Duration() / (time.Second / 20)),
+		Duration:        int32(dur),
 	})
 }
 

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -531,9 +531,9 @@ func (s *Session) SendHealth(health, max, absorption float64) {
 func (s *Session) SendEffect(e effect.Effect) {
 	s.SendEffectRemoval(e.Type())
 	id, _ := effect.ID(e.Type())
-	dur := e.Duration()
-	if dur != -1 {
-		dur = dur / (time.Second / 20)
+	dur := e.Duration() / (time.Second / 20)
+	if e.Infinite() {
+		dur = -1
 	}
 
 	s.writePacket(&packet.MobEffect{


### PR DESCRIPTION
Using `/effect Player effect infinite` in BDS gives the player an infinite duration of that effect, reference the picture below:

![woah !!](https://github.com/user-attachments/assets/2b7c5fbd-c77c-438d-9b9e-696210aefdb6)

Confirmed that it sends a -1 duration. (from BDS)
`&packet.MobEffect{EntityRuntimeID:0x1, Operation:0x2, EffectType:1, Amplifier:10, Particles:false, Duration:-1, Tick:0x0}`
Tested using `p.AddEffect(effect.New(effect.Speed, 1, -1))`

Let me know if I missed something, or did something wrong!