### PR TITLE
Improvement of commandline processing

### DIFF
--- a/server/cmd/command.go
+++ b/server/cmd/command.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/csv"
 	"fmt"
 	"github.com/df-mc/dragonfly/server/world"
 	"go/ast"
@@ -228,7 +229,16 @@ func (cmd Command) executeRunnable(v reflect.Value, args string, source Source, 
 
 	var argFrags []string
 	if args != "" {
-		argFrags = SplitCommandArgs(args)
+		r := csv.NewReader(strings.NewReader(args))
+		r.Comma, r.LazyQuotes = ' ', true
+		record, err := r.Read()
+		if err != nil {
+			// When LazyQuotes is enabled, this really never appears to return
+			// an error when we read only one line. Just in case it does though,
+			// we return the command usage.
+			return nil, MessageUsage.F(cmd.Usage())
+		}
+		argFrags = record
 	}
 	parser := parser{}
 	arguments := &Line{args: argFrags, src: source, seen: []string{"/" + cmd.name}, cmd: cmd}
@@ -334,42 +344,4 @@ func exportedFields(command reflect.Value) []reflect.StructField {
 		fields = append(fields, t)
 	}
 	return fields
-}
-
-// SplitCommandArgs splits str to args for command execution.
-func SplitCommandArgs(str string) []string {
-	var (
-		args          []string
-		arg           strings.Builder
-		quote         bool
-		previousSpace bool
-	)
-
-	for _, char := range str {
-		switch char {
-		case '"':
-			quote = !quote
-		case ' ':
-			if quote {
-				// writing part of the string.
-				arg.WriteRune(char)
-				continue
-			}
-			if previousSpace {
-				// trimming space.
-				continue
-			}
-			// end of the arg.
-			previousSpace = true
-			args = append(args, arg.String())
-			arg.Reset()
-		default:
-			previousSpace = false
-			arg.WriteRune(char)
-		}
-	}
-	if arg.Len() != 0 {
-		args = append(args, arg.String())
-	}
-	return args
 }

--- a/server/cmd/command.go
+++ b/server/cmd/command.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/csv"
 	"fmt"
 	"github.com/df-mc/dragonfly/server/world"
 	"go/ast"
@@ -229,16 +228,7 @@ func (cmd Command) executeRunnable(v reflect.Value, args string, source Source, 
 
 	var argFrags []string
 	if args != "" {
-		r := csv.NewReader(strings.NewReader(args))
-		r.Comma, r.LazyQuotes = ' ', true
-		record, err := r.Read()
-		if err != nil {
-			// When LazyQuotes is enabled, this really never appears to return
-			// an error when we read only one line. Just in case it does though,
-			// we return the command usage.
-			return nil, MessageUsage.F(cmd.Usage())
-		}
-		argFrags = record
+		argFrags = SplitCommandArgs(args)
 	}
 	parser := parser{}
 	arguments := &Line{args: argFrags, src: source, seen: []string{"/" + cmd.name}, cmd: cmd}
@@ -344,4 +334,42 @@ func exportedFields(command reflect.Value) []reflect.StructField {
 		fields = append(fields, t)
 	}
 	return fields
+}
+
+// SplitCommandArgs splits str to args for command execution.
+func SplitCommandArgs(str string) []string {
+	var (
+		args          []string
+		arg           strings.Builder
+		quote         bool
+		previousSpace bool
+	)
+
+	for _, char := range str {
+		switch char {
+		case '"':
+			quote = !quote
+		case ' ':
+			if quote {
+				// writing part of the string.
+				arg.WriteRune(char)
+				continue
+			}
+			if previousSpace {
+				// trimming space.
+				continue
+			}
+			// end of the arg.
+			previousSpace = true
+			args = append(args, arg.String())
+			arg.Reset()
+		default:
+			previousSpace = false
+			arg.WriteRune(char)
+		}
+	}
+	if arg.Len() != 0 {
+		args = append(args, arg.String())
+	}
+	return args
 }

--- a/server/cmd/command.go
+++ b/server/cmd/command.go
@@ -238,7 +238,9 @@ func (cmd Command) executeRunnable(v reflect.Value, args string, source Source, 
 			// we return the command usage.
 			return nil, MessageUsage.F(cmd.Usage())
 		}
-		argFrags = record
+		argFrags = slices.DeleteFunc(record, func(s string) bool {
+			return s == ""
+		})
 	}
 	parser := parser{}
 	arguments := &Line{args: argFrags, src: source, seen: []string{"/" + cmd.name}, cmd: cmd}

--- a/server/cmd/command.go
+++ b/server/cmd/command.go
@@ -238,9 +238,7 @@ func (cmd Command) executeRunnable(v reflect.Value, args string, source Source, 
 			// we return the command usage.
 			return nil, MessageUsage.F(cmd.Usage())
 		}
-		argFrags = slices.DeleteFunc(record, func(s string) bool {
-			return s == ""
-		})
+		argFrags = record
 	}
 	parser := parser{}
 	arguments := &Line{args: argFrags, src: source, seen: []string{"/" + cmd.name}, cmd: cmd}

--- a/server/cmd/command.go
+++ b/server/cmd/command.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/csv"
 	"fmt"
 	"github.com/df-mc/dragonfly/server/world"
 	"go/ast"
@@ -229,18 +228,7 @@ func (cmd Command) executeRunnable(v reflect.Value, args string, source Source, 
 
 	var argFrags []string
 	if args != "" {
-		r := csv.NewReader(strings.NewReader(args))
-		r.Comma, r.LazyQuotes = ' ', true
-		record, err := r.Read()
-		if err != nil {
-			// When LazyQuotes is enabled, this really never appears to return
-			// an error when we read only one line. Just in case it does though,
-			// we return the command usage.
-			return nil, MessageUsage.F(cmd.Usage())
-		}
-		argFrags = slices.DeleteFunc(record, func(s string) bool {
-			return s == ""
-		})
+		argFrags = SplitCommandArgs(args)
 	}
 	parser := parser{}
 	arguments := &Line{args: argFrags, src: source, seen: []string{"/" + cmd.name}, cmd: cmd}
@@ -346,4 +334,42 @@ func exportedFields(command reflect.Value) []reflect.StructField {
 		fields = append(fields, t)
 	}
 	return fields
+}
+
+// SplitCommandArgs splits str to args for command execution.
+func SplitCommandArgs(str string) []string {
+	var (
+		args          []string
+		arg           strings.Builder
+		quote         bool
+		previousSpace bool
+	)
+
+	for _, char := range str {
+		switch char {
+		case '"':
+			quote = !quote
+		case ' ':
+			if quote {
+				// writing part of the string.
+				arg.WriteRune(char)
+				continue
+			}
+			if previousSpace {
+				// trimming space.
+				continue
+			}
+			// end of the arg.
+			previousSpace = true
+			args = append(args, arg.String())
+			arg.Reset()
+		default:
+			previousSpace = false
+			arg.WriteRune(char)
+		}
+	}
+	if arg.Len() != 0 {
+		args = append(args, arg.String())
+	}
+	return args
 }

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -332,15 +332,6 @@ func (p *Player) ExecuteCommand(commandLine string) {
 	}
 	args := strings.Split(commandLine, " ")
 
-	args = slices.DeleteFunc(args, func(s string) bool {
-		return s == ""
-	})
-
-	if len(args[0]) == 1 {
-		args = args[1:]
-		args[0] = "/" + args[0]
-	}
-
 	name, ok := strings.CutPrefix(args[0], "/")
 	if !ok {
 		return

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -332,10 +332,11 @@ func (p *Player) ExecuteCommand(commandLine string) {
 	}
 	args := strings.Split(strings.TrimLeft(commandLine, "/ "), " ")
 
-	name, ok := strings.CutPrefix(args[0], "/")
-	if !ok {
-		return
-	}
+	args = slices.DeleteFunc(args, func(s string) bool {
+		return s == ""
+	})
+
+	name := args[0]
 
 	command, ok := cmd.ByAlias(name)
 	if !ok {

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -330,7 +330,7 @@ func (p *Player) ExecuteCommand(commandLine string) {
 	if p.Dead() {
 		return
 	}
-	args := strings.Split(commandLine, " ")
+	args := cmd.SplitCommandArgs(commandLine)
 
 	name, ok := strings.CutPrefix(args[0], "/")
 	if !ok {

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -332,6 +332,15 @@ func (p *Player) ExecuteCommand(commandLine string) {
 	}
 	args := strings.Split(commandLine, " ")
 
+	args = slices.DeleteFunc(args, func(s string) bool {
+		return s == ""
+	})
+
+	if len(args[0]) == 1 {
+		args = args[1:]
+		args[0] = "/" + args[0]
+	}
+
 	name, ok := strings.CutPrefix(args[0], "/")
 	if !ok {
 		return

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -330,7 +330,7 @@ func (p *Player) ExecuteCommand(commandLine string) {
 	if p.Dead() {
 		return
 	}
-	args := strings.Split(commandLine, " ")
+	args := strings.Split(strings.TrimLeft(commandLine, "/ "), " ")
 
 	name, ok := strings.CutPrefix(args[0], "/")
 	if !ok {

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -330,7 +330,7 @@ func (p *Player) ExecuteCommand(commandLine string) {
 	if p.Dead() {
 		return
 	}
-	args := cmd.SplitCommandArgs(commandLine)
+	args := strings.Split(commandLine, " ")
 
 	name, ok := strings.CutPrefix(args[0], "/")
 	if !ok {


### PR DESCRIPTION
with this change you can put as much spaces as you want into the command
something like this: `/tell "Cool  guy"       hello!  ` will not result an error any more 