### PR TITLE
player.go: prevent panic pick block

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2003,7 +2003,10 @@ func (p *Player) PickBlock(pos cube.Pos) {
 	if pi, ok := b.(block.Pickable); ok {
 		pickedItem = pi.Pick()
 	} else if i, ok := b.(world.Item); ok {
-		it, _ := world.ItemByName(i.EncodeItem())
+		it, ok := world.ItemByName(i.EncodeItem())
+		if !ok {
+			return
+		}
 		pickedItem = item.NewStack(it, 1)
 	} else {
 		return


### PR DESCRIPTION
```
goroutine 1568 [running]:
github.com/df-mc/dragonfly/server/item.NewStack(...)
        /root/go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250227115945-c39dc4d9be42/server/item/stack.go:43
github.com/df-mc/dragonfly/server/player.(*Player).PickBlock(0xc012fc9aa0, {0x1, 0x63, 0xffffffffffffffef})
        /root/go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250227115945-c39dc4d9be42/server/player/player.go:2007 +0x6db
github.com/df-mc/dragonfly/server/session.BlockPickRequestHandler.Handle({}, {0x11f9a50?, 0xc0127fc1a0?}, 0x73df2b4573e8?, 0x46f69a?, {0x121dde8?, 0xc012fc9aa0?})
        /root/go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250227115945-c39dc4d9be42/server/session/handler_block_pick_request.go:15 +0x7a
```