### PR TITLE
Improve p.HideEntity & p.ShowEntity

### DIFF
--- a/server/session/player.go
+++ b/server/session/player.go
@@ -35,7 +35,7 @@ func (s *Session) StopShowingEntity(e world.Entity) {
 	s.entityMutex.Unlock()
 
 	if !ok {
-		s.HideEntity(e)
+		s.doHideEntity(e)
 	}
 }
 
@@ -49,7 +49,7 @@ func (s *Session) StartShowingEntity(e world.Entity) {
 	s.entityMutex.Unlock()
 
 	if ok {
-		s.ViewEntity(e)
+		s.doViewEntity(e)
 		s.ViewEntityState(e)
 		s.ViewEntityItems(e)
 		s.ViewEntityArmour(e)

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -53,6 +53,7 @@ type Session struct {
 	entityRuntimeIDs map[*world.EntityHandle]uint64
 	entities         map[uint64]*world.EntityHandle
 	hiddenEntities   map[uuid.UUID]struct{}
+	visibleEntities  map[uuid.UUID]struct{}
 
 	// heldSlot is the slot in the inventory that the controllable is holding.
 	heldSlot                     *uint32
@@ -155,6 +156,7 @@ func (conf Config) New(conn Conn) *Session {
 		entityRuntimeIDs:       map[*world.EntityHandle]uint64{},
 		entities:               map[uint64]*world.EntityHandle{},
 		hiddenEntities:         map[uuid.UUID]struct{}{},
+		visibleEntities:        map[uuid.UUID]struct{}{},
 		blobs:                  map[uint64][]byte{},
 		chunkRadius:            int32(r),
 		maxChunkRadius:         int32(conf.MaxChunkRadius),


### PR DESCRIPTION
## Current Problem
`(*player.Player).ShowEntity()` allows viewing entities outside the world and player chunks, which is not allowed in PocketMine. This may cause unexpected behavior when showing an entities out of player's chunk range and causing `DEBUG entity runtime ID not found` log spam

## Changes
- Track visible entities from `(*session.Session).ViewEntity` calls.
- Added `(*session.Session).doHideEntity` & `(*session.Session).doViewEntity` 

This may not be a good solution. Opinion needed.