### PR TITLE
Prevent player from sending game mode update to their own session

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1327,7 +1327,7 @@ func (p *Player) SetGameMode(mode world.GameMode) {
 	p.session().SendGameMode(p)
 	for _, v := range p.viewers() {
 		if v == p.session() {
-			return
+			continue
 		}
 		v.ViewEntityGameMode(p)
 	}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1326,6 +1326,9 @@ func (p *Player) SetGameMode(mode world.GameMode) {
 
 	p.session().SendGameMode(p)
 	for _, v := range p.viewers() {
+		if v == p.session() {
+			return
+		}
 		v.ViewEntityGameMode(p)
 	}
 	if mode.AllowsTakingDamage() {


### PR DESCRIPTION
It fixes an issue where the player is unable to fly after setting the gamemode with AllowsFlying set to true, especially when creating a survival gamemode that allows flying.
```go
type flyGamemode struct{}

func (flyGamemode) AllowsEditing() bool      { return false }
func (flyGamemode) AllowsTakingDamage() bool { return true }
func (flyGamemode) CreativeInventory() bool  { return false }
func (flyGamemode) HasCollision() bool       { return true }
func (flyGamemode) AllowsFlying() bool       { return true }
func (flyGamemode) AllowsInteraction() bool  { return true }
func (flyGamemode) Visible() bool            { return true }
```

```go
p.SetGameMode(flyGamemode{})
```

I figured out how to prevent this by not sending the UpdatePlayerGameTypePacket after the UpdateAbilitiesPacket.