### PR TITLE
fix block placing near the player

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1903,7 +1903,7 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 		case entity.ItemType, entity.ArrowType:
 			continue
 		default:
-			if cube.AnyIntersections(blockBoxes, t.BBox(e).Translate(e.Position()).Grow(-1e-6)) {
+			if cube.AnyIntersections(blockBoxes, t.BBox(e).Translate(e.Position()).Grow(-1e-4)) {
 				obstructed = true
 				if e.H() == p.handle {
 					continue


### PR DESCRIPTION
sometimes you just fails to place block, maybe it because of floating point error or something else (it mostly noticeable with very low z axis), but increasing the epsilon fixes this problem without any consequences

The problem:

https://github.com/user-attachments/assets/d8184c4d-5d9f-49f1-b02f-860d12d44672

