### PR TITLE
Fix race condition that result in a deadlock when closing a world.

### DIFF
--- a/server/world/conf.go
+++ b/server/world/conf.go
@@ -100,7 +100,8 @@ func (conf Config) New() *World {
 	var h Handler = NopHandler{}
 	w.handler.Store(&h)
 
-	w.running.Add(3)
+	w.queueing.Add(1)
+	w.running.Add(2)
 
 	t := ticker{interval: time.Second / 20}
 	go t.tickLoop(w)

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -29,7 +29,9 @@ type World struct {
 	conf Config
 	ra   cube.Range
 
-	queue chan transaction
+	queue        chan transaction
+	queueClosing chan struct{}
+	queueing     sync.WaitGroup
 
 	// advance is a bool that specifies if this World should advance the current
 	// tick, time and weather saved in the Settings struct held by the World.
@@ -129,8 +131,8 @@ func (w *World) handleTransactions() {
 		select {
 		case tx := <-w.queue:
 			tx.Run(w)
-		case <-w.closing:
-			w.running.Done()
+		case <-w.queueClosing:
+			w.queueing.Done()
 			return
 		}
 	}
@@ -1013,6 +1015,9 @@ func (w *World) close() {
 
 	close(w.closing)
 	w.running.Wait()
+
+	close(w.queueClosing)
+	w.queueing.Wait()
 
 	if w.set.ref.Add(-1); !w.advance {
 		return


### PR DESCRIPTION
The deadlock happened because `ticker.tickLoop` is waiting for `<-w.Exec(w.tick)` to be executed, while w.handleTransactions goroutine may be stopped during that time. The deadlock doesn't always happen, but it does sometimes.

This PR solved this problem by stopping `tickLoop` and `autoSave` goroutines first, then stopping the `w.handleTransactions` goroutine.

goroutines dump:
```
goroutine 1183 [chan receive, 87 minutes]:
github.com/df-mc/dragonfly/server/world.ticker.tickLoop({0x0?}, 0xc000160f00)
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/tick.go:27 +0x112
created by github.com/df-mc/dragonfly/server/world.Config.New in goroutine 1142
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/conf.go:106 +0x4e5

goroutine 2410 [chan receive, 71 minutes]:
github.com/df-mc/dragonfly/server/world.ticker.tickLoop({0x17f5f78?}, 0xc0243cf200)
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/tick.go:27 +0x112
created by github.com/df-mc/dragonfly/server/world.Config.New in goroutine 2368
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/conf.go:106 +0x4e5

goroutine 2740 [chan receive, 77 minutes]:
github.com/df-mc/dragonfly/server/world.ticker.tickLoop({0x17f5f48?}, 0xc000161c80)
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/tick.go:27 +0x112
created by github.com/df-mc/dragonfly/server/world.Config.New in goroutine 2721
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/conf.go:106 +0x4e5

goroutine 3178 [sync.WaitGroup.Wait, 77 minutes]:
sync.runtime_SemacquireWaitGroup(0x411500?)
        /usr/local/go/src/runtime/sema.go:110 +0x25
sync.(*WaitGroup).Wait(0xc00a2272d0?)
        /usr/local/go/src/sync/waitgroup.go:118 +0x48
github.com/df-mc/dragonfly/server/world.(*World).close(0xc000161c80)
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/world.go:1015 +0xfb
sync.(*Once).doSlow(0x1?, 0xc011af7fd0?)
        /usr/local/go/src/sync/once.go:78 +0xab
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:69
github.com/df-mc/dragonfly/server/world.(*World).Close(...)
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/world.go:999
github.com/kuduga/df-game.(*Game).close.func2()
        /go/pkg/mod/github.com/kuduga/df-game@v0.0.0-20250426133827-ab40e0989fa4/game.go:965 +0x54
created by github.com/kuduga/df-game.(*Game).close in goroutine 2742
        /go/pkg/mod/github.com/kuduga/df-game@v0.0.0-20250426133827-ab40e0989fa4/game.go:964 +0x319

goroutine 2316 [sync.WaitGroup.Wait, 87 minutes]:
sync.runtime_SemacquireWaitGroup(0x411500?)
        /usr/local/go/src/runtime/sema.go:110 +0x25
sync.(*WaitGroup).Wait(0xc015a3b030?)
        /usr/local/go/src/sync/waitgroup.go:118 +0x48
github.com/df-mc/dragonfly/server/world.(*World).close(0xc000160f00)
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/world.go:1015 +0xfb
sync.(*Once).doSlow(0x1?, 0x7d5858922b01?)
        /usr/local/go/src/sync/once.go:78 +0xab
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:69
github.com/df-mc/dragonfly/server/world.(*World).Close(...)
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/world.go:999
github.com/kuduga/df-game.(*Game).close.func2()
        /go/pkg/mod/github.com/kuduga/df-game@v0.0.0-20250426133827-ab40e0989fa4/game.go:965 +0x54
created by github.com/kuduga/df-game.(*Game).close in goroutine 1201
        /go/pkg/mod/github.com/kuduga/df-game@v0.0.0-20250426133827-ab40e0989fa4/game.go:964 +0x319

goroutine 3530 [sync.WaitGroup.Wait, 71 minutes]:
sync.runtime_SemacquireWaitGroup(0x411500?)
        /usr/local/go/src/runtime/sema.go:110 +0x25
sync.(*WaitGroup).Wait(0xc00db6a460?)
        /usr/local/go/src/sync/waitgroup.go:118 +0x48
github.com/df-mc/dragonfly/server/world.(*World).close(0xc0243cf200)
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/world.go:1015 +0xfb
sync.(*Once).doSlow(0x455e2da79762?, 0x0?)
        /usr/local/go/src/sync/once.go:78 +0xab
sync.(*Once).Do(...)
        /usr/local/go/src/sync/once.go:69
github.com/df-mc/dragonfly/server/world.(*World).Close(...)
        /go/pkg/mod/github.com/akmalfairuz/dragonfly@v0.0.0-20250427104152-4b4710854802/server/world/world.go:999
github.com/kuduga/df-game.(*Game).close.func2()
        /go/pkg/mod/github.com/kuduga/df-game@v0.0.0-20250426133827-ab40e0989fa4/game.go:965 +0x54
created by github.com/kuduga/df-game.(*Game).close in goroutine 2412
        /go/pkg/mod/github.com/kuduga/df-game@v0.0.0-20250426133827-ab40e0989fa4/game.go:964 +0x319
```