### PR TITLE
update world data

### DIFF
--- a/server/world/mcdb/leveldat/data.go
+++ b/server/world/mcdb/leveldat/data.go
@@ -193,7 +193,6 @@ func (d *Data) FillDefault() {
 	d.LimitedWorldDepth = 16
 	d.LimitedWorldOriginY = math.MaxInt16
 	d.LimitedWorldWidth = 16
-	d.LocatorBar = false
 	d.MaxCommandChainLength = math.MaxUint16
 	d.MinimumCompatibleClientVersion = minimumCompatibleClientVersion
 	d.MobGriefing = true

--- a/server/world/mcdb/leveldat/data.go
+++ b/server/world/mcdb/leveldat/data.go
@@ -35,6 +35,7 @@ type Data struct {
 	LimitedWorldOriginZ            int32
 	LimitedWorldDepth              int32 `nbt:"limitedWorldDepth"`
 	LimitedWorldWidth              int32 `nbt:"limitedWorldWidth"`
+	LocatorBar                     bool  `nbt:"locatorbar"`
 	MinimumCompatibleClientVersion []int32
 	MultiPlayerGame                bool `nbt:"MultiplayerGame"`
 	MultiPlayerGameIntent          bool `nbt:"MultiplayerGameIntent"`
@@ -192,6 +193,7 @@ func (d *Data) FillDefault() {
 	d.LimitedWorldDepth = 16
 	d.LimitedWorldOriginY = math.MaxInt16
 	d.LimitedWorldWidth = 16
+	d.LocatorBar = false
 	d.MaxCommandChainLength = math.MaxUint16
 	d.MinimumCompatibleClientVersion = minimumCompatibleClientVersion
 	d.MobGriefing = true


### PR DESCRIPTION
adds locatorbar to world data

fixes 

open db: unmarshal level.dat: level.dat: decode nbt: nbt: unexpected named tag '.locatorbar' with type TAG_Byte at offset 2040: not present in struct to be decoded into