### PR TITLE
fix session.Conn hooking

### DIFF
--- a/server/session/session.go
+++ b/server/session/session.go
@@ -188,7 +188,7 @@ func (conf Config) New(conn Conn) *Session {
 			case <-s.closeBackground:
 				return
 			case pk := <-s.packets:
-				_ = conn.WritePacket(pk)
+				_ = s.conn.WritePacket(pk)
 			}
 		}
 	}()


### PR DESCRIPTION
since this [commit](https://github.com/df-mc/dragonfly/commit/405843c030a778f4cd2c2e49c4f556c070414f6e) it is no longer possible to handle client-bound packets by hooking session.Conn interface, this pr makes it possible again