### PR TITLE
item/stack.go: WithValue set data to nil when data len is zero

### DIFF
--- a/server/item/stack.go
+++ b/server/item/stack.go
@@ -244,6 +244,9 @@ func (s Stack) WithValue(key string, val any) Stack {
 		s.data[key] = val
 	} else {
 		delete(s.data, key)
+		if len(s.data) == 0 {
+			s.data = nil
+		}
 	}
 	return s
 }


### PR DESCRIPTION
## Problem
```go
a := item.NewStack(item.Feather{}, 1)
a = a.WithValue("x", 1)
a = a.WithValue("x", nil) // x is removed here

b := item.NewStack(item.Feather{}, 1)
a.Comparable(b) // false, this should return true
```