### PR TITLE
player/debug: Add support for new debug drawing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-gl/mathgl v1.2.0
 	github.com/google/uuid v1.6.0
 	github.com/pelletier/go-toml v1.9.5
-	github.com/sandertv/gophertunnel v1.47.2
+	github.com/sandertv/gophertunnel v1.47.4
 	github.com/segmentio/fasthash v1.0.3
 	golang.org/x/exp v0.0.0-20250103183323-7d7fa50e5329
 	golang.org/x/mod v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -39,10 +39,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sandertv/go-raknet v1.14.3-0.20250305181847-6af3e95113d6 h1:ZfK7NCzIDE+dzp5x6NIO4JDLsjsOxi762CNR1Obds2Q=
 github.com/sandertv/go-raknet v1.14.3-0.20250305181847-6af3e95113d6/go.mod h1:/yysjwfCXm2+2OY8mBazLzcxJ3irnylKCyG3FLgUPVU=
-github.com/sandertv/gophertunnel v1.46.0 h1:NmXs5YL+7MkY7gt1qs3XF6+5J6/MdlX7W9hi4YFE1p4=
-github.com/sandertv/gophertunnel v1.46.0/go.mod h1:lvzOdyb2fkoo3uySe++hy4UKq0I649oUFJKkro2ZHpY=
-github.com/sandertv/gophertunnel v1.47.2 h1:vW8KVBjykC+rMdVMDsPkZHp3MM2bVneYhxzvVN4XyE4=
-github.com/sandertv/gophertunnel v1.47.2/go.mod h1:lvzOdyb2fkoo3uySe++hy4UKq0I649oUFJKkro2ZHpY=
+github.com/sandertv/gophertunnel v1.47.4 h1:PmNbEUf9+7Fk8bP2875cvYTt22g0d4eeQhtd1dxjqqA=
+github.com/sandertv/gophertunnel v1.47.4/go.mod h1:lvzOdyb2fkoo3uySe++hy4UKq0I649oUFJKkro2ZHpY=
 github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
 github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/server/player/debug/renderer.go
+++ b/server/player/debug/renderer.go
@@ -1,0 +1,14 @@
+package debug
+
+// Renderer represents an interface for a renderer that can manage debug shapes.
+type Renderer interface {
+	// AddDebugShape adds a debug shape to the renderer, which should be rendered to the player. If the shape
+	// already exists, it will be updated with the new information.
+	AddDebugShape(shape Shape)
+	// RemoveDebugShape removes a debug shape from the renderer by its unique identifier.
+	RemoveDebugShape(shape Shape)
+	// VisibleDebugShapes returns a slice of all debug shapes that are currently being shown by the renderer.
+	VisibleDebugShapes() []Shape
+	// RemoveAllDebugShapes clears all debug shapes from the renderer, removing them from the view of the player.
+	RemoveAllDebugShapes()
+}

--- a/server/player/debug/shape.go
+++ b/server/player/debug/shape.go
@@ -1,0 +1,130 @@
+package debug
+
+import (
+	"fmt"
+	"github.com/go-gl/mathgl/mgl64"
+	"image/color"
+	"sync/atomic"
+)
+
+var nextShapeID atomic.Int32
+
+// Shape represents a shape that can be drawn to a player from any point in the world.
+type Shape interface {
+	// ShapeID returns the unique identifier of the shape. This is used to either update or remove the shape
+	// after it has been sent to the player.
+	ShapeID() int
+}
+
+// shape is a base type for all shapes that implements the Shape interface. It contains a unique identifier
+// that is lazily initialized when the ShapeID method is called for the first time.
+type shape struct {
+	id *int
+}
+
+// ShapeID ...
+func (s *shape) ShapeID() int {
+	if s.id == nil {
+		id := int(nextShapeID.Add(1))
+		fmt.Println("Assigning shape ID:", id)
+		s.id = &id
+	}
+	return *s.id
+}
+
+// Arrow represents an arrow shape that can be drawn at any point in the world. It has a head which can also
+// be positioned anywhere, and the length, radius and number of segments can be changed.
+type Arrow struct {
+	shape
+
+	// Colour is the colour that will be used for the line and head. If empty, it will default to white.
+	Colour color.RGBA
+	// Position is the origin position of the shape in the world.
+	Position mgl64.Vec3
+	// EndPosition is the end position of the arrow in the world. The arrow will be drawn from Position to
+	// EndPosition, with the head being drawn at EndPosition.
+	EndPosition mgl64.Vec3
+	// HeadLength is the length of the head to be drawn at the end of the arrow. If zero, it will default
+	// to 1.0.
+	HeadLength float64
+	// HeadRadius is the radius of the head to be drawn at the end of the arrow. If zero, it will default
+	// to 0.5.
+	HeadRadius float64
+	// HeadSegments is the number of segments that the head of the arrow will be drawn with. The more
+	// segments, the smoother the head will look. If zero, it will default to 4.
+	HeadSegments int
+}
+
+// Box represents a hollow box that can be drawn at any point in the world, with a bounds that can be set.
+type Box struct {
+	shape
+
+	// Colour is the colour that will be used for the outline. If empty, it will default to white.
+	Colour color.RGBA
+	// Bounds is the size of the box in the world, acting as an offset from the Position. If empty,
+	// it will default to a 1x1x1 box.
+	Bounds mgl64.Vec3
+	// Position is the origin position of the shape in the world.
+	Position mgl64.Vec3
+	// Scale is the rate to scale the shape from its origin point. If zero, it will default to 1.0.
+	Scale float64
+}
+
+// Circle represents a hollow circle that can be drawn at any point in the world, with the scale being used
+// to control the radius.
+type Circle struct {
+	shape
+
+	// Colour is the colour that will be used for the outline. If empty, it will default to white.
+	Colour color.RGBA
+	// Position is the origin position of the shape in the world.
+	Position mgl64.Vec3
+	// Scale is the radius of the circle. If zero, it will default to 1.0.
+	Scale float64
+	// Segments is the number of segments that the circle will be drawn with. The more segments, the smoother
+	// the circle will look. If empty, it will default to 20.
+	Segments int
+}
+
+// Line represents a line that can be drawn at any point in the world, with a start and end position.
+type Line struct {
+	shape
+
+	// Colour is the colour that will be used for the line. If empty, it will default to white.
+	Colour color.RGBA
+	// Position is the origin position of the shape in the world.
+	Position mgl64.Vec3
+	// EndPosition is the end position of the line in the world. The line will be drawn from Position to
+	// EndPosition.
+	EndPosition mgl64.Vec3
+}
+
+// Sphere represents a hollow sphere that can be drawn at any point in the world, with one line in each axis.
+// The scale is used to control the radius of the sphere.
+type Sphere struct {
+	shape
+
+	// Colour is the colour that will be used for the outline. If empty, it will default to white.
+	Colour color.RGBA
+	// Position is the origin position of the shape in the world.
+	Position mgl64.Vec3
+	// Scale is the radius of the sphere. If zero, it will default to 1.0.
+	Scale float64
+	// Segments is the number of segments that the circle will be drawn with. The more segments, the smoother
+	// the circle will look. If empty, it will default to 20.
+	Segments int
+}
+
+// Text represents text that can be drawn at any point in the world, looking like a normal entity nametag
+// without actually being attached to an entity.
+type Text struct {
+	shape
+
+	// Colour is the colour that will be used for the actual text, not affecting the always-black background.
+	// If empty, the text will default to white.
+	Colour color.RGBA
+	// Position is the origin position of the shape in the world.
+	Position mgl64.Vec3
+	// Text is the text to be displayed on the shape. The background automatically scales to fit the text.
+	Text string
+}

--- a/server/player/debug/shape.go
+++ b/server/player/debug/shape.go
@@ -1,7 +1,6 @@
 package debug
 
 import (
-	"fmt"
 	"github.com/go-gl/mathgl/mgl64"
 	"image/color"
 	"sync/atomic"
@@ -26,7 +25,6 @@ type shape struct {
 func (s *shape) ShapeID() int {
 	if s.id == nil {
 		id := int(nextShapeID.Add(1))
-		fmt.Println("Assigning shape ID:", id)
 		s.id = &id
 	}
 	return *s.id

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2,6 +2,7 @@ package player
 
 import (
 	"fmt"
+	"github.com/df-mc/dragonfly/server/player/debug"
 	"math"
 	"math/rand/v2"
 	"net"
@@ -2433,6 +2434,8 @@ func (p *Player) Tick(tx *world.Tx, current int64) {
 		}
 	}
 
+	p.s.SendDebugShapes()
+
 	if p.prevWorld != tx.World() && p.prevWorld != nil {
 		p.Handler().HandleChangeWorld(p, p.prevWorld, tx.World())
 	}
@@ -2854,6 +2857,28 @@ func (p *Player) PunchAir() {
 // UpdateDiagnostics updates the diagnostics of the player.
 func (p *Player) UpdateDiagnostics(d session.Diagnostics) {
 	p.Handler().HandleDiagnostics(p, d)
+}
+
+// AddDebugShape adds a debug shape to be rendered to the player. If the shape already exists, it will be
+// updated with the new information.
+func (p *Player) AddDebugShape(shape debug.Shape) {
+	p.s.AddDebugShape(shape)
+}
+
+// RemoveDebugShape removes a debug shape from the player by its unique identifier.
+func (p *Player) RemoveDebugShape(shape debug.Shape) {
+	p.s.RemoveDebugShape(shape)
+}
+
+// VisibleDebugShapes returns a slice of all debug shapes that are currently being shown to the player.
+func (p *Player) VisibleDebugShapes() []debug.Shape {
+	return p.s.VisibleDebugShapes()
+}
+
+// RemoveAllDebugShapes removes all rendered debug shapes from the player, as well as any shapes that have
+// not yet been rendered.
+func (p *Player) RemoveAllDebugShapes() {
+	p.s.RemoveAllDebugShapes()
 }
 
 // damageItem damages the item stack passed with the damage passed and returns the new stack. If the item

--- a/server/session/controllable.go
+++ b/server/session/controllable.go
@@ -7,6 +7,7 @@ import (
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/item/inventory"
 	"github.com/df-mc/dragonfly/server/player/chat"
+	"github.com/df-mc/dragonfly/server/player/debug"
 	"github.com/df-mc/dragonfly/server/player/dialogue"
 	"github.com/df-mc/dragonfly/server/player/form"
 	"github.com/df-mc/dragonfly/server/player/skin"
@@ -27,6 +28,7 @@ type Controllable interface {
 	form.Submitter
 	cmd.Source
 	chat.Subscriber
+	debug.Renderer
 
 	Locale() language.Tag
 

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -789,6 +789,8 @@ func (s *Session) RemoveAllDebugShapes() {
 	}
 }
 
+// SendDebugShapes sends any pending additions/removals of debug shapes to the player. Shapes should be sent
+// every tick to allow for batching and time-efficient updates.
 func (s *Session) SendDebugShapes() {
 	s.debugShapesMu.Lock()
 	defer s.debugShapesMu.Unlock()
@@ -814,6 +816,8 @@ loop:
 	s.writePacket(&packet.ServerScriptDebugDrawer{Shapes: shapes})
 }
 
+// debugShapeToProtocol converts a debug shape to its protocol representation. It also provides defaults
+// for some fields such as colour, scale and other per-shape properties.
 func (s *Session) debugShapeToProtocol(shape debug.Shape) packet.DebugDrawerShape {
 	ps := packet.DebugDrawerShape{NetworkID: uint64(shape.ShapeID())}
 	white := color.RGBA{R: 255, G: 255, B: 255, A: 255}
@@ -860,6 +864,8 @@ func (s *Session) debugShapeToProtocol(shape debug.Shape) packet.DebugDrawerShap
 	return ps
 }
 
+// valueOrDefault returns the value passed if it is not the zero value of the type T, otherwise it returns
+// the default value provided.
 func valueOrDefault[T comparable](v, def T) T {
 	var zero T
 	if v == zero {

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -764,9 +764,7 @@ func (s *Session) RemoveDebugShape(shape debug.Shape) {
 	s.debugShapesMu.RLock()
 	defer s.debugShapesMu.RUnlock()
 
-	fmt.Println(shape.ShapeID())
 	if _, ok := s.debugShapes[shape.ShapeID()]; ok {
-		fmt.Println("Removing shape", shape.ShapeID())
 		s.debugShapesRemove <- shape.ShapeID()
 	}
 }

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -3,6 +3,10 @@ package session
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/df-mc/dragonfly/server/player/debug"
+	"github.com/go-gl/mathgl/mgl32"
+	"image/color"
+	"maps"
 	"math"
 	"net"
 	"slices"
@@ -747,6 +751,123 @@ func (s *Session) SendChargeItemComplete() {
 		EntityRuntimeID: selfEntityRuntimeID,
 		EventType:       packet.ActorEventFinishedChargingItem,
 	})
+}
+
+// AddDebugShape adds a debug shape to be rendered to the player. If the shape already exists, it will be
+// updated with the new information.
+func (s *Session) AddDebugShape(shape debug.Shape) {
+	s.debugShapesAdd <- shape
+}
+
+// RemoveDebugShape removes a debug shape from the player by its unique identifier.
+func (s *Session) RemoveDebugShape(shape debug.Shape) {
+	s.debugShapesMu.RLock()
+	defer s.debugShapesMu.RUnlock()
+
+	fmt.Println(shape.ShapeID())
+	if _, ok := s.debugShapes[shape.ShapeID()]; ok {
+		fmt.Println("Removing shape", shape.ShapeID())
+		s.debugShapesRemove <- shape.ShapeID()
+	}
+}
+
+// VisibleDebugShapes returns a slice of all debug shapes that are currently being shown to the player.
+func (s *Session) VisibleDebugShapes() []debug.Shape {
+	s.debugShapesMu.RLock()
+	defer s.debugShapesMu.RUnlock()
+
+	return slices.Collect(maps.Values(s.debugShapes))
+}
+
+// RemoveAllDebugShapes removes all rendered debug shapes from the player, as well as any shapes that have
+// not yet been rendered.
+func (s *Session) RemoveAllDebugShapes() {
+	s.debugShapesMu.Lock()
+	defer s.debugShapesMu.Unlock()
+
+	s.debugShapesAdd = make(chan debug.Shape, 256)
+	for id := range s.debugShapes {
+		s.debugShapesRemove <- id
+	}
+}
+
+func (s *Session) SendDebugShapes() {
+	s.debugShapesMu.Lock()
+	defer s.debugShapesMu.Unlock()
+
+	if len(s.debugShapesAdd) == 0 && len(s.debugShapesRemove) == 0 {
+		return
+	}
+
+	shapes := make([]packet.DebugDrawerShape, 0, len(s.debugShapesAdd)+len(s.debugShapesRemove))
+loop:
+	for {
+		select {
+		case shape := <-s.debugShapesAdd:
+			s.debugShapes[shape.ShapeID()] = shape
+			shapes = append(shapes, s.debugShapeToProtocol(shape))
+		case id := <-s.debugShapesRemove:
+			delete(s.debugShapes, id)
+			shapes = append(shapes, packet.DebugDrawerShape{NetworkID: uint64(id)})
+		default:
+			break loop
+		}
+	}
+	s.writePacket(&packet.ServerScriptDebugDrawer{Shapes: shapes})
+}
+
+func (s *Session) debugShapeToProtocol(shape debug.Shape) packet.DebugDrawerShape {
+	ps := packet.DebugDrawerShape{NetworkID: uint64(shape.ShapeID())}
+	white := color.RGBA{R: 255, G: 255, B: 255, A: 255}
+	switch shape := shape.(type) {
+	case *debug.Arrow:
+		ps.Type = protocol.Option(uint8(packet.ScriptDebugShapeArrow))
+		ps.Colour = protocol.Option(valueOrDefault(shape.Colour, white))
+		ps.Location = protocol.Option(vec64To32(shape.Position))
+		ps.LineEndLocation = protocol.Option(vec64To32(shape.EndPosition))
+		ps.ArrowHeadLength = protocol.Option(valueOrDefault(float32(shape.HeadLength), 1))
+		ps.ArrowHeadRadius = protocol.Option(valueOrDefault(float32(shape.HeadRadius), 0.5))
+		ps.Segments = protocol.Option(valueOrDefault(uint8(shape.HeadSegments), 4))
+	case *debug.Box:
+		ps.Type = protocol.Option(uint8(packet.ScriptDebugShapeBox))
+		ps.Colour = protocol.Option(valueOrDefault(shape.Colour, white))
+		ps.BoxBound = protocol.Option(valueOrDefault(vec64To32(shape.Bounds), mgl32.Vec3{1, 1, 1}))
+		ps.Location = protocol.Option(vec64To32(shape.Position))
+		ps.Scale = protocol.Option(valueOrDefault(float32(shape.Scale), 1))
+	case *debug.Circle:
+		ps.Type = protocol.Option(uint8(packet.ScriptDebugShapeCircle))
+		ps.Colour = protocol.Option(valueOrDefault(shape.Colour, white))
+		ps.Location = protocol.Option(vec64To32(shape.Position))
+		ps.Scale = protocol.Option(valueOrDefault(float32(shape.Scale), 1))
+		ps.Segments = protocol.Option(valueOrDefault(uint8(shape.Segments), 20))
+	case *debug.Line:
+		ps.Type = protocol.Option(uint8(packet.ScriptDebugShapeLine))
+		ps.Colour = protocol.Option(valueOrDefault(shape.Colour, white))
+		ps.Location = protocol.Option(vec64To32(shape.Position))
+		ps.LineEndLocation = protocol.Option(vec64To32(shape.EndPosition))
+	case *debug.Sphere:
+		ps.Type = protocol.Option(uint8(packet.ScriptDebugShapeSphere))
+		ps.Colour = protocol.Option(valueOrDefault(shape.Colour, white))
+		ps.Location = protocol.Option(vec64To32(shape.Position))
+		ps.Scale = protocol.Option(valueOrDefault(float32(shape.Scale), 1))
+		ps.Segments = protocol.Option(valueOrDefault(uint8(shape.Segments), 20))
+	case *debug.Text:
+		ps.Type = protocol.Option(uint8(packet.ScriptDebugShapeText))
+		ps.Colour = protocol.Option(valueOrDefault(shape.Colour, white))
+		ps.Location = protocol.Option(vec64To32(shape.Position))
+		ps.Text = protocol.Option(shape.Text)
+	default:
+		panic(fmt.Sprintf("unknown debug shape type %T", shape))
+	}
+	return ps
+}
+
+func valueOrDefault[T comparable](v, def T) T {
+	var zero T
+	if v == zero {
+		return def
+	}
+	return v
 }
 
 // stackFromItem converts an item.Stack to its network ItemStack representation.

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/df-mc/dragonfly/server/player/debug"
 	"io"
 	"log/slog"
 	"net"
@@ -84,6 +85,11 @@ type Session struct {
 	blobs                 map[uint64][]byte
 	openChunkTransactions []map[uint64]struct{}
 	invOpened             bool
+
+	debugShapesMu     sync.RWMutex
+	debugShapes       map[int]debug.Shape
+	debugShapesAdd    chan debug.Shape
+	debugShapesRemove chan int
 
 	closeBackground chan struct{}
 }
@@ -166,6 +172,9 @@ func (conf Config) New(conn Conn) *Session {
 		heldSlot:               new(uint32),
 		recipes:                make(map[uint32]recipe.Recipe),
 		conf:                   conf,
+		debugShapes:            make(map[int]debug.Shape),
+		debugShapesAdd:         make(chan debug.Shape, 256),
+		debugShapesRemove:      make(chan int, 256),
 	}
 	s.openedWindow.Store(inventory.New(1, nil))
 	s.openedPos.Store(&cube.Pos{})


### PR DESCRIPTION
Implements full coverage of the new debug drawer functionality, with batching. Shapes are added to add/remove queues until the next tick where all the pending actions are sent to the client.

Rotation does nothing when provided for any shape, so it has been omitted.
Duration does nothing when provided for any shape, so it has been omitted.

Arrows, Boxes, Circles, Lines, Spheres & Text can be created. Text supports any RGBA colour (for the whole line), and may be a suitable replacement for Dragonfly's floating text option.

Example for adding a red sphere with 100 segments:
```go
p.AddDebugShape(&debug.Sphere{
	Colour: color.RGBA{R: 255, A: 255},
	Position: p.Position(),
	Segments: 100,
})```