### PR TITLE
Fix: Use p.session() instead of p.s for debug shape.

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2434,7 +2434,7 @@ func (p *Player) Tick(tx *world.Tx, current int64) {
 		}
 	}
 
-	p.s.SendDebugShapes()
+	p.session().SendDebugShapes()
 
 	if p.prevWorld != tx.World() && p.prevWorld != nil {
 		p.Handler().HandleChangeWorld(p, p.prevWorld, tx.World())
@@ -2862,23 +2862,23 @@ func (p *Player) UpdateDiagnostics(d session.Diagnostics) {
 // AddDebugShape adds a debug shape to be rendered to the player. If the shape already exists, it will be
 // updated with the new information.
 func (p *Player) AddDebugShape(shape debug.Shape) {
-	p.s.AddDebugShape(shape)
+	p.session().AddDebugShape(shape)
 }
 
 // RemoveDebugShape removes a debug shape from the player by its unique identifier.
 func (p *Player) RemoveDebugShape(shape debug.Shape) {
-	p.s.RemoveDebugShape(shape)
+	p.session().RemoveDebugShape(shape)
 }
 
 // VisibleDebugShapes returns a slice of all debug shapes that are currently being shown to the player.
 func (p *Player) VisibleDebugShapes() []debug.Shape {
-	return p.s.VisibleDebugShapes()
+	return p.session().VisibleDebugShapes()
 }
 
 // RemoveAllDebugShapes removes all rendered debug shapes from the player, as well as any shapes that have
 // not yet been rendered.
 func (p *Player) RemoveAllDebugShapes() {
-	p.s.RemoveAllDebugShapes()
+	p.session().RemoveAllDebugShapes()
 }
 
 // damageItem damages the item stack passed with the damage passed and returns the new stack. If the item


### PR DESCRIPTION
currently players with nil session would cause nil panic (NPE), this PR dedicated to fix that.