### PR TITLE
Fix: Custom Block Items Not Rendering Correctly

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -399,11 +399,16 @@ func (srv *Server) makeItemComponents() {
 	for _, it := range custom {
 		name, _ := it.EncodeItem()
 		rid, _, _ := world.ItemRuntimeID(it)
+		_, isCustomBlock := it.(world.CustomBlock)
+		var entryVersion int32 = protocol.ItemEntryVersionDataDriven
+		if isCustomBlock {
+			entryVersion = protocol.ItemEntryVersionNone
+		}
 		srv.customItems = append(srv.customItems, protocol.ItemEntry{
 			Name:           name,
-			ComponentBased: true,
+			ComponentBased: !isCustomBlock,
 			RuntimeID:      int16(rid),
-			Version:        protocol.ItemEntryVersionDataDriven,
+			Version:        entryVersion,
 			Data:           iteminternal.Components(it),
 		})
 	}


### PR DESCRIPTION
This pull request addresses an issue where custom block items were not rendering correctly when dropped in the world or held in the inventory. Previously, these items would appear as an invisible item.