### PR TITLE
minecraft:icon takes in the identifier as is!

### DIFF
--- a/server/internal/iteminternal/builder.go
+++ b/server/internal/iteminternal/builder.go
@@ -53,7 +53,7 @@ func (builder *ComponentBuilder) Construct() map[string]any {
 func (builder *ComponentBuilder) applyDefaultProperties(x map[string]any) {
 	x["minecraft:icon"] = map[string]any{
 		"textures": map[string]any{
-			"default": strings.Split(builder.identifier, ":")[1],
+			"default": builder.identifier,
 		},
 	}
 	x["creative_group"] = builder.category.Group()


### PR DESCRIPTION
JSON UI Documentation:
In RP/textures/item_texture.json:
{
    "resource_pack_name": "wiki",
    "texture_name": "atlas.items",
    "texture_data": {
        "wiki:custom_item": {
            "textures": "textures/items/custom_item"
        }
    }
}

In BP/items/custom_item.json:
{
    "format_version": "1.21.90",
    "minecraft:item": {
        "description": {
            "identifier": "wiki:custom_item",
            "menu_category": {
                "category": "construction"
            }
        },
        "components": {
            "minecraft:icon": "wiki:custom_item"
        }
    }
}


As you can see, the documentation shows the identifier is taken the same way; it takes "wiki:custom_item", not "custom_item"

df needs to do the same, otherwise there'll be a discrepancy between how behavior pack and dragonfly understands the item's icon texture