### PR TITLE
feat(server/world): Implement armor visiblity to per-viewer view layers

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2612,12 +2612,17 @@ func (p *Player) ViewVisibility(entity world.Entity, level world.VisibilityLevel
 	p.session().ViewVisibility(entity, level)
 }
 
-// ViewArmour overrides whether the public armour of the entity is visible for this player.
-func (p *Player) ViewArmour(entity world.Entity, visible bool) {
-	p.session().ViewArmour(entity, visible)
+// ViewArmour overrides the public armour of the entity for this player.
+func (p *Player) ViewArmour(entity world.Entity, helmet, chestplate, leggings, boots item.Stack) {
+	p.session().ViewArmour(entity, helmet, chestplate, leggings, boots)
 }
 
-// ViewPublicArmour removes the armour visibility override of the entity for this player.
+// ViewNoArmour hides the armour of the entity for this player.
+func (p *Player) ViewNoArmour(entity world.Entity) {
+	p.session().ViewNoArmour(entity)
+}
+
+// ViewPublicArmour removes the armour override of the entity for this player.
 func (p *Player) ViewPublicArmour(entity world.Entity) {
 	p.session().ViewPublicArmour(entity)
 }

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2612,6 +2612,16 @@ func (p *Player) ViewVisibility(entity world.Entity, level world.VisibilityLevel
 	p.session().ViewVisibility(entity, level)
 }
 
+// ViewArmour overrides whether the public armour of the entity is visible for this player.
+func (p *Player) ViewArmour(entity world.Entity, visible bool) {
+	p.session().ViewArmour(entity, visible)
+}
+
+// ViewPublicArmour removes the armour visibility override of the entity for this player.
+func (p *Player) ViewPublicArmour(entity world.Entity) {
+	p.session().ViewPublicArmour(entity)
+}
+
 // RemoveViewLayer removes all view-layer overrides of the entity for this player.
 func (p *Player) RemoveViewLayer(entity world.Entity) {
 	p.session().RemoveViewLayer(entity)

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -99,7 +99,9 @@ type Session struct {
 	debugShapes       map[int]debug.Shape
 	debugShapeUpdates []debugShapeUpdate
 
-	viewLayer *world.ViewLayer
+	viewLayer         *world.ViewLayer
+	viewLayerArmourMu sync.RWMutex
+	viewLayerArmour   map[*world.EntityHandle]viewLayerArmour
 
 	closeBackground chan struct{}
 
@@ -200,6 +202,7 @@ func (conf Config) New(conn Conn) *Session {
 		hiddenHud:              make(map[hud.Element]struct{}),
 		debugShapes:            make(map[int]debug.Shape),
 		debugShapeUpdates:      make([]debugShapeUpdate, 0, 256),
+		viewLayerArmour:        make(map[*world.EntityHandle]viewLayerArmour),
 	}
 	s.viewLayer = world.NewViewLayer(s)
 	s.openedWindow.Store(inventory.New(1, nil))
@@ -300,6 +303,9 @@ func (s *Session) close(tx *world.Tx, c Controllable) {
 	if s.viewLayer != nil {
 		_ = s.viewLayer.Close()
 	}
+	s.viewLayerArmourMu.Lock()
+	clear(s.viewLayerArmour)
+	s.viewLayerArmourMu.Unlock()
 
 	s.conf.HandleStop(tx, c)
 

--- a/server/session/view_layer.go
+++ b/server/session/view_layer.go
@@ -48,6 +48,22 @@ func (s *Session) ViewVisibility(entity world.Entity, level world.VisibilityLeve
 	s.viewLayer.ViewVisibility(entity, level)
 }
 
+// ViewArmour overwrites whether the public armour of the entity is visible and immediately refreshes it for this session.
+func (s *Session) ViewArmour(entity world.Entity, visible bool) {
+	if s.viewLayer == nil {
+		return
+	}
+	s.viewLayer.ViewArmour(entity, visible)
+}
+
+// ViewPublicArmour removes the armour visibility override from the entity and immediately refreshes it for this session.
+func (s *Session) ViewPublicArmour(entity world.Entity) {
+	if s.viewLayer == nil {
+		return
+	}
+	s.viewLayer.ViewPublicArmour(entity)
+}
+
 // RemoveViewLayer removes all overrides for the entity and immediately refreshes it for this session.
 func (s *Session) RemoveViewLayer(entity world.Entity) {
 	if s.viewLayer == nil {
@@ -62,6 +78,14 @@ func (s *Session) ViewLayerEntityChanged(e world.Entity) {
 		return
 	}
 	s.ViewEntityState(e)
+}
+
+// ViewLayerArmourChanged refreshes the entity armour for this session if the entity is currently visible.
+func (s *Session) ViewLayerArmourChanged(e world.Entity) {
+	if s.entityHidden(e) || !s.viewingEntity(e.H()) {
+		return
+	}
+	s.ViewEntityArmour(e)
 }
 
 // viewingEntity checks if this session currently has a runtime ID assigned to the entity handle.

--- a/server/session/view_layer.go
+++ b/server/session/view_layer.go
@@ -1,6 +1,13 @@
 package session
 
-import "github.com/df-mc/dragonfly/server/world"
+import (
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+type viewLayerArmour struct {
+	helmet, chestplate, leggings, boots item.Stack
+}
 
 // ViewLayer returns the session's ViewLayer. The layer may be used to override how entities are viewed
 // by this session, such as with a different name tag or visibility state.
@@ -46,22 +53,39 @@ func (s *Session) ViewVisibility(entity world.Entity, level world.VisibilityLeve
 		return
 	}
 	s.viewLayer.ViewVisibility(entity, level)
+	s.viewLayerArmourChanged(entity)
 }
 
-// ViewArmour overwrites whether the public armour of the entity is visible and immediately refreshes it for this session.
-func (s *Session) ViewArmour(entity world.Entity, visible bool) {
+// ViewArmour overwrites the public armour of the entity and immediately refreshes it for this session.
+func (s *Session) ViewArmour(entity world.Entity, helmet, chestplate, leggings, boots item.Stack) {
 	if s.viewLayer == nil {
 		return
 	}
-	s.viewLayer.ViewArmour(entity, visible)
+	s.viewLayerArmourMu.Lock()
+	s.viewLayerArmour[entity.H()] = viewLayerArmour{
+		helmet:     helmet,
+		chestplate: chestplate,
+		leggings:   leggings,
+		boots:      boots,
+	}
+	s.viewLayerArmourMu.Unlock()
+	s.viewLayerArmourChanged(entity)
 }
 
-// ViewPublicArmour removes the armour visibility override from the entity and immediately refreshes it for this session.
+// ViewNoArmour hides the armour of the entity and immediately refreshes it for this session.
+func (s *Session) ViewNoArmour(entity world.Entity) {
+	s.ViewArmour(entity, item.Stack{}, item.Stack{}, item.Stack{}, item.Stack{})
+}
+
+// ViewPublicArmour removes the armour override from the entity and immediately refreshes it for this session.
 func (s *Session) ViewPublicArmour(entity world.Entity) {
 	if s.viewLayer == nil {
 		return
 	}
-	s.viewLayer.ViewPublicArmour(entity)
+	s.viewLayerArmourMu.Lock()
+	delete(s.viewLayerArmour, entity.H())
+	s.viewLayerArmourMu.Unlock()
+	s.viewLayerArmourChanged(entity)
 }
 
 // RemoveViewLayer removes all overrides for the entity and immediately refreshes it for this session.
@@ -70,6 +94,10 @@ func (s *Session) RemoveViewLayer(entity world.Entity) {
 		return
 	}
 	s.viewLayer.Remove(entity)
+	s.viewLayerArmourMu.Lock()
+	delete(s.viewLayerArmour, entity.H())
+	s.viewLayerArmourMu.Unlock()
+	s.viewLayerArmourChanged(entity)
 }
 
 // ViewLayerEntityChanged refreshes the entity metadata for this session if the entity is currently visible.
@@ -80,12 +108,19 @@ func (s *Session) ViewLayerEntityChanged(e world.Entity) {
 	s.ViewEntityState(e)
 }
 
-// ViewLayerArmourChanged refreshes the entity armour for this session if the entity is currently visible.
-func (s *Session) ViewLayerArmourChanged(e world.Entity) {
+// viewLayerArmourChanged refreshes the entity armour for this session if the entity is currently visible.
+func (s *Session) viewLayerArmourChanged(e world.Entity) {
 	if s.entityHidden(e) || !s.viewingEntity(e.H()) {
 		return
 	}
 	s.ViewEntityArmour(e)
+}
+
+func (s *Session) viewedArmour(entity world.Entity) (viewLayerArmour, bool) {
+	s.viewLayerArmourMu.RLock()
+	armour, ok := s.viewLayerArmour[entity.H()]
+	s.viewLayerArmourMu.RUnlock()
+	return armour, ok
 }
 
 // viewingEntity checks if this session currently has a runtime ID assigned to the entity handle.

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -311,6 +311,23 @@ func (s *Session) ViewEntityArmour(e world.Entity) {
 		return
 	}
 
+	if s.viewLayer != nil {
+		visible, ok := s.viewLayer.ArmourVisible(e)
+		if !ok && s.viewLayer.Visibility(e) == world.EnforceInvisible() {
+			visible, ok = false, true
+		}
+		if ok && !visible {
+			s.writePacket(&packet.MobArmourEquipment{
+				EntityRuntimeID: runtimeID,
+				Helmet:          instanceFromItem(s.br, item.Stack{}),
+				Chestplate:      instanceFromItem(s.br, item.Stack{}),
+				Leggings:        instanceFromItem(s.br, item.Stack{}),
+				Boots:           instanceFromItem(s.br, item.Stack{}),
+			})
+			return
+		}
+	}
+
 	inv := armoured.Armour()
 
 	// Show the entity's armour

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -311,32 +311,23 @@ func (s *Session) ViewEntityArmour(e world.Entity) {
 		return
 	}
 
-	if s.viewLayer != nil {
-		visible, ok := s.viewLayer.ArmourVisible(e)
-		if !ok && s.viewLayer.Visibility(e) == world.EnforceInvisible() {
-			visible, ok = false, true
-		}
-		if ok && !visible {
-			s.writePacket(&packet.MobArmourEquipment{
-				EntityRuntimeID: runtimeID,
-				Helmet:          instanceFromItem(s.br, item.Stack{}),
-				Chestplate:      instanceFromItem(s.br, item.Stack{}),
-				Leggings:        instanceFromItem(s.br, item.Stack{}),
-				Boots:           instanceFromItem(s.br, item.Stack{}),
-			})
-			return
-		}
+	var helmet, chestplate, leggings, boots item.Stack
+	if armour, ok := s.viewedArmour(e); ok {
+		helmet, chestplate, leggings, boots = armour.helmet, armour.chestplate, armour.leggings, armour.boots
+	} else if s.viewLayer != nil && s.viewLayer.Visibility(e) == world.EnforceInvisible() {
+		helmet, chestplate, leggings, boots = item.Stack{}, item.Stack{}, item.Stack{}, item.Stack{}
+	} else {
+		inv := armoured.Armour()
+		helmet, chestplate, leggings, boots = inv.Helmet(), inv.Chestplate(), inv.Leggings(), inv.Boots()
 	}
-
-	inv := armoured.Armour()
 
 	// Show the entity's armour
 	s.writePacket(&packet.MobArmourEquipment{
 		EntityRuntimeID: runtimeID,
-		Helmet:          instanceFromItem(s.br, inv.Helmet()),
-		Chestplate:      instanceFromItem(s.br, inv.Chestplate()),
-		Leggings:        instanceFromItem(s.br, inv.Leggings()),
-		Boots:           instanceFromItem(s.br, inv.Boots()),
+		Helmet:          instanceFromItem(s.br, helmet),
+		Chestplate:      instanceFromItem(s.br, chestplate),
+		Leggings:        instanceFromItem(s.br, leggings),
+		Boots:           instanceFromItem(s.br, boots),
 	})
 }
 

--- a/server/world/view_layer.go
+++ b/server/world/view_layer.go
@@ -10,7 +10,6 @@ import (
 type layer struct {
 	nameTag    *string
 	scoreTag   *string
-	armour     *bool
 	visibility VisibilityLevel
 }
 
@@ -20,17 +19,12 @@ type ViewLayerUpdater interface {
 	ViewLayerEntityChanged(entity Entity)
 }
 
-type viewLayerArmourUpdater interface {
-	// ViewLayerArmourChanged handles an entity whose view-layer armour override changed.
-	ViewLayerArmourChanged(entity Entity)
-}
-
 type viewLayerViewer interface {
 	ViewLayer() *ViewLayer
 }
 
 // ViewLayer holds overrides for how entities are viewed by a single viewer. It allows entities to be
-// viewed differently by different players, such as with a different name tag, visibility state or armour.
+// viewed differently by different players, such as with a different name tag or visibility state.
 type ViewLayer struct {
 	mu       sync.RWMutex
 	entities map[*EntityHandle]layer
@@ -115,7 +109,6 @@ func (v *ViewLayer) ViewVisibility(entity Entity, level VisibilityLevel) {
 	v.update(entity, func(l *layer) {
 		l.visibility = level
 	})
-	v.refreshArmour(entity)
 }
 
 // Visibility returns the visibility of the entity.
@@ -126,39 +119,10 @@ func (v *ViewLayer) Visibility(entity Entity) VisibilityLevel {
 	return v.entities[entity.H()].visibility
 }
 
-// ViewArmour overwrites whether the entity's public armour is visible to this ViewLayer. Passing false hides
-// the armour, and passing true shows it even if the entity is forced invisible for this ViewLayer.
-func (v *ViewLayer) ViewArmour(entity Entity, visible bool) {
-	v.updateArmour(entity, func(l *layer) {
-		l.armour = &visible
-	})
-}
-
-// ViewPublicArmour removes the armour visibility override from the entity, causing the public armour visibility
-// to be viewed again.
-func (v *ViewLayer) ViewPublicArmour(entity Entity) {
-	v.updateArmour(entity, func(l *layer) {
-		l.armour = nil
-	})
-}
-
-// ArmourVisible returns whether the entity's public armour should be visible and whether an override was set.
-func (v *ViewLayer) ArmourVisible(entity Entity) (bool, bool) {
-	v.mu.RLock()
-	defer v.mu.RUnlock()
-
-	visible := v.entities[entity.H()].armour
-	if visible == nil {
-		return false, false
-	}
-	return *visible, true
-}
-
 // Remove removes all overrides for the entity from the ViewLayer.
 func (v *ViewLayer) Remove(entity Entity) {
 	if v.remove(entity) {
 		v.refresh(entity)
-		v.refreshArmour(entity)
 	}
 }
 
@@ -192,24 +156,6 @@ func (v *ViewLayer) update(entity Entity, update func(*layer)) {
 	v.refresh(entity)
 }
 
-// updateArmour applies a mutation to the entity's layer, removes the entry if no overrides remain, and refreshes
-// the entity's armour for the layer's viewer.
-func (v *ViewLayer) updateArmour(entity Entity, update func(*layer)) {
-	handle := entity.H()
-
-	v.mu.Lock()
-	l := v.entities[handle]
-	update(&l)
-	if l.empty() {
-		delete(v.entities, handle)
-	} else {
-		v.entities[handle] = l
-	}
-	v.mu.Unlock()
-
-	v.refreshArmour(entity)
-}
-
 // Close closes the view layer.
 func (v *ViewLayer) Close() error {
 	v.mu.Lock()
@@ -219,19 +165,13 @@ func (v *ViewLayer) Close() error {
 	return nil
 }
 
-// empty checks if the layer does not override any public entity view state.
+// empty checks if the layer does not override any public entity metadata.
 func (l layer) empty() bool {
-	return l.nameTag == nil && l.scoreTag == nil && l.armour == nil && l.visibility == PublicVisibility()
+	return l.nameTag == nil && l.scoreTag == nil && l.visibility == PublicVisibility()
 }
 
 func (v *ViewLayer) refresh(entity Entity) {
 	if v.updater != nil {
 		v.updater.ViewLayerEntityChanged(entity)
-	}
-}
-
-func (v *ViewLayer) refreshArmour(entity Entity) {
-	if updater, ok := v.updater.(viewLayerArmourUpdater); ok {
-		updater.ViewLayerArmourChanged(entity)
 	}
 }

--- a/server/world/view_layer.go
+++ b/server/world/view_layer.go
@@ -10,6 +10,7 @@ import (
 type layer struct {
 	nameTag    *string
 	scoreTag   *string
+	armour     *bool
 	visibility VisibilityLevel
 }
 
@@ -19,12 +20,17 @@ type ViewLayerUpdater interface {
 	ViewLayerEntityChanged(entity Entity)
 }
 
+type viewLayerArmourUpdater interface {
+	// ViewLayerArmourChanged handles an entity whose view-layer armour override changed.
+	ViewLayerArmourChanged(entity Entity)
+}
+
 type viewLayerViewer interface {
 	ViewLayer() *ViewLayer
 }
 
 // ViewLayer holds overrides for how entities are viewed by a single viewer. It allows entities to be
-// viewed differently by different players, such as with a different name tag or visibility state.
+// viewed differently by different players, such as with a different name tag, visibility state or armour.
 type ViewLayer struct {
 	mu       sync.RWMutex
 	entities map[*EntityHandle]layer
@@ -109,6 +115,7 @@ func (v *ViewLayer) ViewVisibility(entity Entity, level VisibilityLevel) {
 	v.update(entity, func(l *layer) {
 		l.visibility = level
 	})
+	v.refreshArmour(entity)
 }
 
 // Visibility returns the visibility of the entity.
@@ -119,10 +126,39 @@ func (v *ViewLayer) Visibility(entity Entity) VisibilityLevel {
 	return v.entities[entity.H()].visibility
 }
 
+// ViewArmour overwrites whether the entity's public armour is visible to this ViewLayer. Passing false hides
+// the armour, and passing true shows it even if the entity is forced invisible for this ViewLayer.
+func (v *ViewLayer) ViewArmour(entity Entity, visible bool) {
+	v.updateArmour(entity, func(l *layer) {
+		l.armour = &visible
+	})
+}
+
+// ViewPublicArmour removes the armour visibility override from the entity, causing the public armour visibility
+// to be viewed again.
+func (v *ViewLayer) ViewPublicArmour(entity Entity) {
+	v.updateArmour(entity, func(l *layer) {
+		l.armour = nil
+	})
+}
+
+// ArmourVisible returns whether the entity's public armour should be visible and whether an override was set.
+func (v *ViewLayer) ArmourVisible(entity Entity) (bool, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	visible := v.entities[entity.H()].armour
+	if visible == nil {
+		return false, false
+	}
+	return *visible, true
+}
+
 // Remove removes all overrides for the entity from the ViewLayer.
 func (v *ViewLayer) Remove(entity Entity) {
 	if v.remove(entity) {
 		v.refresh(entity)
+		v.refreshArmour(entity)
 	}
 }
 
@@ -156,6 +192,24 @@ func (v *ViewLayer) update(entity Entity, update func(*layer)) {
 	v.refresh(entity)
 }
 
+// updateArmour applies a mutation to the entity's layer, removes the entry if no overrides remain, and refreshes
+// the entity's armour for the layer's viewer.
+func (v *ViewLayer) updateArmour(entity Entity, update func(*layer)) {
+	handle := entity.H()
+
+	v.mu.Lock()
+	l := v.entities[handle]
+	update(&l)
+	if l.empty() {
+		delete(v.entities, handle)
+	} else {
+		v.entities[handle] = l
+	}
+	v.mu.Unlock()
+
+	v.refreshArmour(entity)
+}
+
 // Close closes the view layer.
 func (v *ViewLayer) Close() error {
 	v.mu.Lock()
@@ -165,13 +219,19 @@ func (v *ViewLayer) Close() error {
 	return nil
 }
 
-// empty checks if the layer does not override any public entity metadata.
+// empty checks if the layer does not override any public entity view state.
 func (l layer) empty() bool {
-	return l.nameTag == nil && l.scoreTag == nil && l.visibility == PublicVisibility()
+	return l.nameTag == nil && l.scoreTag == nil && l.armour == nil && l.visibility == PublicVisibility()
 }
 
 func (v *ViewLayer) refresh(entity Entity) {
 	if v.updater != nil {
 		v.updater.ViewLayerEntityChanged(entity)
+	}
+}
+
+func (v *ViewLayer) refreshArmour(entity Entity) {
+	if updater, ok := v.updater.(viewLayerArmourUpdater); ok {
+		updater.ViewLayerArmourChanged(entity)
 	}
 }


### PR DESCRIPTION
A caveat to https://github.com/df-mc/dragonfly/commit/b9a408ac6b28efed82a9a051d983cfbb827ae60d is that armor is not hidden when a player goes out of a view. This means that a player could still be visible if they are wearing armor which may be an unintended side effect.

This PR implements the ability to manually choose to display armor as visible.