### PR TITLE
server: Fix golden apple absorption stacking and depletion.

### DIFF
--- a/server/item/golden_apple.go
+++ b/server/item/golden_apple.go
@@ -22,7 +22,9 @@ func (e GoldenApple) ConsumeDuration() time.Duration {
 // Consume ...
 func (e GoldenApple) Consume(_ *world.Tx, c Consumer) Stack {
 	c.Saturate(4, 9.6)
+	prev := c.Absorption()
 	c.AddEffect(effect.New(effect.Absorption, 1, 2*time.Minute))
+	c.SetAbsorption(max(prev, min(prev+4, 16)))
 	c.AddEffect(effect.New(effect.Regeneration, 2, 5*time.Second))
 	return Stack{}
 }

--- a/server/item/item.go
+++ b/server/item/item.go
@@ -91,6 +91,11 @@ type Consumer interface {
 	// Effects returns any effect currently applied to the Consumer. The returned effects are guaranteed not to have
 	// expired when returned.
 	Effects() []effect.Effect
+	// Absorption returns the absorption health of the Consumer.
+	Absorption() float64
+	// SetAbsorption sets the absorption health of the Consumer. Absorption health is shown as golden hearts and does
+	// not regenerate naturally.
+	SetAbsorption(health float64)
 }
 
 // DefaultConsumeDuration is the default duration that consuming an item takes. Dried kelp takes half this

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -602,8 +602,12 @@ func (p *Player) Hurt(dmg float64, src world.DamageSource) (float64, bool) {
 	p.setAttackImmunity(immunity, totalDamage)
 
 	if a := p.Absorption(); a > 0 {
-		p.SetAbsorption(a - damageLeft)
+		remaining := a - damageLeft
+		p.SetAbsorption(remaining)
 		damageLeft = max(0, damageLeft-a)
+		if remaining <= 0 {
+			p.RemoveEffect(effect.Absorption)
+		}
 	}
 
 	if p.Health()-damageLeft <= mgl64.Epsilon && !src.IgnoreTotem() {

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -605,7 +605,7 @@ func (p *Player) Hurt(dmg float64, src world.DamageSource) (float64, bool) {
 		remaining := a - damageLeft
 		p.SetAbsorption(remaining)
 		damageLeft = max(0, damageLeft-a)
-		if remaining <= 0 {
+		if _, exists := p.Effect(effect.Absorption); exists && remaining <= 0 {
 			p.RemoveEffect(effect.Absorption)
 		}
 	}


### PR DESCRIPTION
Fixes 2 parity bugs with Minecraft: Bedrock Edition:
  - Golden apples now stack absorption additively up to 8 golden hearts.
  - The Absorption effect is now cleared the instant all golden hearts are lost to damage, instead of lingering for the remainder of its duration.