### PR TITLE
session/chunk.go: skip nil block entity NBT

### DIFF
--- a/server/session/chunk.go
+++ b/server/session/chunk.go
@@ -104,6 +104,9 @@ func (s *Session) subChunkEntry(offset protocol.SubChunkOffset, ind int16, col *
 	for pos, b := range col.BlockEntities {
 		if n, ok := b.(world.NBTer); ok && col.SubIndex(int16(pos.Y())) == ind {
 			d := n.EncodeNBT()
+			if d == nil {
+				continue
+			}
 			d["x"], d["y"], d["z"] = int32(pos[0]), int32(pos[1]), int32(pos[2])
 			_ = enc.Encode(d)
 		}
@@ -184,6 +187,9 @@ func (s *Session) sendBlobHashes(pos world.ChunkPos, dim world.Dimension, c *chu
 	for bp, b := range blockEntities {
 		if n, ok := b.(world.NBTer); ok {
 			d := n.EncodeNBT()
+			if d == nil {
+				continue
+			}
 			d["x"], d["y"], d["z"] = int32(bp[0]), int32(bp[1]), int32(bp[2])
 			_ = enc.Encode(d)
 		}
@@ -226,6 +232,9 @@ func (s *Session) sendNetworkChunk(pos world.ChunkPos, dim world.Dimension, c *c
 	for bp, b := range blockEntities {
 		if n, ok := b.(world.NBTer); ok {
 			d := n.EncodeNBT()
+			if d == nil {
+				continue
+			}
 			d["x"], d["y"], d["z"] = int32(bp[0]), int32(bp[1]), int32(bp[2])
 			_ = enc.Encode(d)
 		}

--- a/server/session/chunk.go
+++ b/server/session/chunk.go
@@ -105,7 +105,7 @@ func (s *Session) subChunkEntry(offset protocol.SubChunkOffset, ind int16, col *
 		if n, ok := b.(world.NBTer); ok && col.SubIndex(int16(pos.Y())) == ind {
 			d := n.EncodeNBT()
 			if d == nil {
-				continue
+				d = make(map[string]any)
 			}
 			d["x"], d["y"], d["z"] = int32(pos[0]), int32(pos[1]), int32(pos[2])
 			_ = enc.Encode(d)
@@ -188,7 +188,7 @@ func (s *Session) sendBlobHashes(pos world.ChunkPos, dim world.Dimension, c *chu
 		if n, ok := b.(world.NBTer); ok {
 			d := n.EncodeNBT()
 			if d == nil {
-				continue
+				d = make(map[string]any)
 			}
 			d["x"], d["y"], d["z"] = int32(bp[0]), int32(bp[1]), int32(bp[2])
 			_ = enc.Encode(d)
@@ -233,7 +233,7 @@ func (s *Session) sendNetworkChunk(pos world.ChunkPos, dim world.Dimension, c *c
 		if n, ok := b.(world.NBTer); ok {
 			d := n.EncodeNBT()
 			if d == nil {
-				continue
+				d = make(map[string]any)
 			}
 			d["x"], d["y"], d["z"] = int32(bp[0]), int32(bp[1]), int32(bp[2])
 			_ = enc.Encode(d)


### PR DESCRIPTION
## Summary
- initialize nil block entity NBT maps before adding coordinates during subchunk encoding
- apply the same nil-map handling to cached and uncached chunk sends