### PR TITLE
server/item: Add vanilla launch spread to bow and crossbow arrows

### DIFF
--- a/server/item/bow.go
+++ b/server/item/bow.go
@@ -80,7 +80,7 @@ func (Bow) Release(releaser Releaser, tx *world.Tx, ctx *UseContext, duration ti
 	create := tx.World().EntityRegistry().Config().Arrow
 	opts := world.EntitySpawnOpts{
 		Position: eyePosition(releaser),
-		Velocity: releaser.Rotation().Vec3().Mul(force * 5),
+		Velocity: releaser.Rotation().Vec3().Add(spreadOffset()).Mul(force * 5),
 		Rotation: releaser.Rotation().Neg(),
 	}
 	projectile := tx.AddEntity(create(opts, world.ArrowSpawnConfig{

--- a/server/item/crossbow.go
+++ b/server/item/crossbow.go
@@ -164,7 +164,7 @@ func (c Crossbow) CanCharge(releaser Releaser, _ *world.Tx, ctx *UseContext) boo
 // shoot fires the crossbow's loaded projectiles.
 func (c Crossbow) shoot(releaser Releaser, tx *world.Tx, offsetAngle float64, arrowConf world.ArrowSpawnConfig) {
 	rot := releaser.Rotation()
-	dirVec := cube.Rotation{rot[0] + offsetAngle, rot[1]}.Vec3()
+	dirVec := cube.Rotation{rot[0] + offsetAngle, rot[1]}.Vec3().Add(spreadOffset())
 
 	if firework, ok := c.Item.Item().(Firework); ok {
 		createFirework := tx.World().EntityRegistry().Config().Firework

--- a/server/item/item.go
+++ b/server/item/item.go
@@ -3,6 +3,7 @@ package item
 import (
 	"encoding/binary"
 	"image/color"
+	"math/rand/v2"
 	"time"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
@@ -243,6 +244,21 @@ func torsoPosition(e world.Entity) mgl64.Vec3 {
 		pos = pos.Add(mgl64.Vec3{0, torso.TorsoHeight()})
 	}
 	return pos
+}
+
+// maxProjectileSpread is the maximum deviation applied to each axis of an arrow's launch direction. It matches the
+// inaccuracy vanilla applies to arrows fired from a bow or crossbow.
+const maxProjectileSpread = 0.0172275
+
+// spreadOffset returns a random offset distributed triangularly over the range [-maxProjectileSpread, maxProjectileSpread]
+// on each axis. It is added to the unit launch direction before it is scaled by power, so arrows do not fly in a
+// perfectly straight line, matching vanilla behaviour.
+func spreadOffset() mgl64.Vec3 {
+	return mgl64.Vec3{
+		maxProjectileSpread * (rand.Float64() - rand.Float64()),
+		maxProjectileSpread * (rand.Float64() - rand.Float64()),
+		maxProjectileSpread * (rand.Float64() - rand.Float64()),
+	}
 }
 
 // Int32FromRGBA converts a color.RGBA into an int32. These int32s are present in things such as signs and dyed leather armour.


### PR DESCRIPTION
Adds the small launch inaccuracy vanilla applies to arrows fired from a bow or crossbow (#1208): a triangular per-axis offset of up to 0.0172275, added to the unit launch direction before it is scaled by power.

Thrown snowballs, eggs and ender pearls are intentionally left straight — in Bedrock their `minecraft:projectile` component carries no uncertainty, so they fly straight from the aim vector.

Closes #1208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
