### PR TITLE
server: Fix spectator game mode behaviour

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1486,6 +1486,9 @@ func (p *Player) SetCooldown(item world.Item, cooldown time.Duration) {
 // unless the held item implements the item.Usable interface, in which case it will be activated.
 // This generally happens for items such as throwable items like snowballs.
 func (p *Player) UseItem() {
+	if !p.GameMode().AllowsInteraction() {
+		return
+	}
 	i, _ := p.HeldItems()
 	ctx := event.C(p)
 	if p.HasCooldown(i.Item()) {

--- a/server/session/handler_player_auth_input.go
+++ b/server/session/handler_player_auth_input.go
@@ -145,7 +145,13 @@ func (h PlayerAuthInputHandler) handleInputFlags(flags protocol.Bitset, s *Sessi
 		}
 	}
 	if flags.Load(packet.InputFlagStopFlying) {
-		c.StopFlying()
+		if !c.GameMode().HasCollision() {
+			// Modes without collision, such as spectator, fly permanently and
+			// may not stop, so correct the client that tried to.
+			s.SendAbilities(c)
+		} else {
+			c.StopFlying()
+		}
 	}
 }
 

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -1257,7 +1257,7 @@ func gameTypeFromMode(mode world.GameMode) int32 {
 		return packet.GameTypeCreative
 	}
 	if !mode.Visible() && !mode.HasCollision() {
-		return packet.GameTypeSurvivalSpectator
+		return packet.GameTypeSpectator
 	}
 	return packet.GameTypeSurvival
 }


### PR DESCRIPTION
### Problem

A player in `GameModeSpectator` was broken in several ways (#1033): other players could still see them, they kept the survival hearts/hotbar HUD, they could use items, and they could toggle flight off.

### Cause & fix

The client was never put into true spectator mode, and a couple of server-side gates were missing.

- **`server/session/player.go`** — `gameTypeFromMode` returned the legacy `GameTypeSurvivalSpectator` (3). Send the modern `GameTypeSpectator` (6) instead. This game type is reported both to the spectator's own client (`SetPlayerGameType`) and to other clients (`AddPlayer` / `UpdatePlayerGameType`); `AddPlayer` documents that a `GameTypeSpectator` player "will not be shown to viewers", so this fixes the visibility and HUD symptoms at once.
- **`server/player/player.go`** — `UseItem` (air use: eating, drinking, throwing, charging a bow) had no interaction gate, so a spectator could use items. Add an early `AllowsInteraction()` check, mirroring the existing gates on `UseItemOnBlock`/`UseItemOnEntity` (via `canReach`) and `ReleaseItem`. `AllowsInteraction()` is `false` only for spectator, so survival/creative/adventure are unaffected.
- **`server/session/handler_player_auth_input.go`** — the client's stop-flying request was always honoured. For a collision-less mode (spectator) flight is permanent, so ignore it and resend the abilities to correct the client. Creative still toggles flight normally.

### Note

Entering spectator also sets the metadata invisibility flag (`SetInvisible`). Now that the modern game type drives client-side hiding, that hack is largely redundant and over-hides spectators from one another (vanilla shows a translucent ghost). Making it viewer-aware is left as a follow-up to keep this change focused.

Fixes #1033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
