### PR TITLE
player/player.go: Stop treating blocks passed while falling as ground

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2866,7 +2866,9 @@ func (p *Player) checkEntitySteppers() {
 
 // checkOnGround checks if the player is currently considered to be on the ground.
 func (p *Player) checkOnGround(deltaPos mgl64.Vec3) bool {
-	box := Type.BBox(p).Translate(p.Position()).Extend(mgl64.Vec3{0, -0.05}).Extend(deltaPos.Mul(-1.0))
+	// Probe straight down (0.05 plus this tick's descent) instead of along the
+	// whole movement, so a block the player falls past at its side is not ground.
+	box := Type.BBox(p).Translate(p.Position()).Extend(mgl64.Vec3{0, -0.05}).Extend(mgl64.Vec3{0, math.Min(deltaPos[1], 0)})
 	b := box.Grow(1)
 
 	epsilon := mgl64.Vec3{mgl64.Epsilon, mgl64.Epsilon, mgl64.Epsilon}


### PR DESCRIPTION
Reworked from #1283 per @TwistedAsylumMC's review: this fixes the root cause in `checkOnGround` rather than patching the fall-damage path. (The original PR could not be reopened because the branch was force-pushed while it was closed.)

### Problem

When a player falls close to a block at its side it takes premature fall damage (#1003). The cause is `checkOnGround`: it extended the probe box opposite to the whole movement (`deltaPos.Mul(-1.0)`), which while falling pushes the box upwards and sideways, so a block next to the fall path intersects it and the player is wrongly reported on the ground.

### Fix

Extend the probe straight **down** only — by 0.05 plus the tick's descent — keeping the player's exact horizontal footprint:

```go
.Extend(mgl64.Vec3{0, -0.05}).Extend(mgl64.Vec3{0, math.Min(deltaPos[1], 0)})
```

A block at the side is no longer mistaken for ground, while a stepped or fast descent still finds the ground beneath the footprint. `updateFallState` is left untouched.

### Testing

Verified in-game on 1.26.30:
- sprinting and walking down a 15-step staircase deals no fall damage (#1044 preserved);
- a ~15-block open fall deals the expected ~6 hearts;
- falling flush alongside a wall deals the same damage, and only on landing (#1003 fixed).

Fixes #1003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
