### PR TITLE
server/world: Add a cancellable neighbour update event

### DIFF
--- a/server/world/handler.go
+++ b/server/world/handler.go
@@ -66,6 +66,11 @@ type Handler interface {
 	// HandleRedstoneUpdate handles a redstone update at a position. ctx.Cancel() may be called
 	// to cancel the redstone update.
 	HandleRedstoneUpdate(ctx *Context, pos cube.Pos)
+	// HandleNeighbourUpdate handles a block at pos being updated because of a change to a
+	// neighbouring block at changedNeighbour. It is only called for a block or liquid that
+	// reacts to the change, that is, one implementing NeighbourUpdateTicker. ctx.Cancel() may
+	// be called to prevent both the block and any liquid at the position from being updated.
+	HandleNeighbourUpdate(ctx *Context, pos, changedNeighbour cube.Pos)
 	// HandleClose handles the World being closed. HandleClose may be used as a
 	// moment to finish code running on other goroutines that operates on the
 	// World specifically. HandleClose is called directly before the World stops
@@ -93,4 +98,5 @@ func (NopHandler) HandleEntitySpawn(*Tx, Entity)                                
 func (NopHandler) HandleEntityDespawn(*Tx, Entity)                                               {}
 func (NopHandler) HandleExplosion(*Context, mgl64.Vec3, *[]Entity, *[]cube.Pos, *float64, *bool) {}
 func (NopHandler) HandleRedstoneUpdate(*Context, cube.Pos)                                       {}
+func (NopHandler) HandleNeighbourUpdate(*Context, cube.Pos, cube.Pos)                            {}
 func (NopHandler) HandleClose(*Tx)                                                               {}

--- a/server/world/tick.go
+++ b/server/world/tick.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/internal/sliceutil"
 )
 
@@ -102,13 +103,21 @@ func (t ticker) performNeighbourUpdates(tx *Tx) {
 
 	for _, update := range updates {
 		pos, changedNeighbour := update.pos, update.neighbour
-		if ticker, ok := tx.Block(pos).(NeighbourUpdateTicker); ok {
-			ticker.NeighbourUpdateTick(pos, changedNeighbour, tx)
+		blockTicker, blockOk := tx.Block(pos).(NeighbourUpdateTicker)
+		liquid, _ := tx.World().additionalLiquid(pos)
+		liquidTicker, liquidOk := liquid.(NeighbourUpdateTicker)
+		if !blockOk && !liquidOk {
+			continue
 		}
-		if liquid, ok := tx.World().additionalLiquid(pos); ok {
-			if ticker, ok := liquid.(NeighbourUpdateTicker); ok {
-				ticker.NeighbourUpdateTick(pos, changedNeighbour, tx)
-			}
+		ctx := event.C(tx)
+		if tx.World().Handler().HandleNeighbourUpdate(ctx, pos, changedNeighbour); ctx.Cancelled() {
+			continue
+		}
+		if blockOk {
+			blockTicker.NeighbourUpdateTick(pos, changedNeighbour, tx)
+		}
+		if liquidOk {
+			liquidTicker.NeighbourUpdateTick(pos, changedNeighbour, tx)
 		}
 	}
 }


### PR DESCRIPTION
Adds a cancellable event for neighbour-triggered block updates — the equivalent of PocketMine's `BlockUpdateEvent` (#1002) — mirroring the existing `HandleRedstoneUpdate`.

### What

`world.Handler.HandleNeighbourUpdate(ctx *Context, pos, changedNeighbour cube.Pos)` (plus the `NopHandler` stub) is fired from `performNeighbourUpdates` before a queued neighbour update is dispatched. `ctx.Cancel()` skips the update for both the block and any liquid at the position.

### Design note

The event is fired **only** for positions whose block or liquid implements `NeighbourUpdateTicker` — it gates updates that would actually run, rather than firing for every queued position. This keeps the veto use case precise and avoids an allocation per inert neighbour (a block change queues the position plus its six neighbours, most of which do not react).

This differs from PocketMine's `BlockUpdateEvent`, which fires regardless. If you would prefer observe-everything semantics, the event call can be hoisted above the ticker-existence check with only the dispatch gated on cancellation — happy to change it.

Closes #1002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
