### PR TITLE
server: Add a settable player list name

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -441,6 +441,24 @@ func (p *Player) NameTag() string {
 	return p.nameTag
 }
 
+// SetPlayerListName changes the name shown for the player in the player list on the pause screen. Unlike
+// SetNameTag, it does not change the name tag displayed over the player in-game.
+func (p *Player) SetPlayerListName(name string) {
+	if p.session() == session.Nop {
+		return
+	}
+	p.session().UpdatePlayerListName(name, p.Skin())
+}
+
+// PlayerListName returns the name shown for the player in the player list on the pause screen, as changed
+// using SetPlayerListName. It defaults to the player's name.
+func (p *Player) PlayerListName() string {
+	if p.session() == session.Nop {
+		return p.Name()
+	}
+	return p.session().PlayerListName()
+}
+
 // SetScoreTag changes the score tag displayed over the player in-game. The score tag is displayed under the player's
 // name tag.
 func (p *Player) SetScoreTag(a ...any) {

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -69,6 +69,10 @@ type Session struct {
 	// spawn for the player list, but otherwise updated immediately when the
 	// player is viewed.
 	joinSkin skin.Skin
+	// name is the name shown for the session in the player list on the pause
+	// screen. It defaults to the connection's display name. Guarded by
+	// entityMutex.
+	name string
 
 	breakingPos cube.Pos
 
@@ -244,7 +248,23 @@ func (s *Session) SetHandle(handle *world.EntityHandle, skin skin.Skin) {
 	s.entities[selfEntityRuntimeID] = handle
 
 	s.joinSkin = skin
+	s.name = s.conn.IdentityData().DisplayName
 	sessions.Add(s)
+}
+
+// PlayerListName returns the name shown for the Session in the player list on
+// the pause screen, which defaults to the connection's display name.
+func (s *Session) PlayerListName() string {
+	s.entityMutex.RLock()
+	defer s.entityMutex.RUnlock()
+	return s.name
+}
+
+// UpdatePlayerListName changes the name shown for the Session in the player
+// list on the pause screen and resends its entry, with the skin passed, to
+// every session.
+func (s *Session) UpdatePlayerListName(name string, sk skin.Skin) {
+	sessions.UpdateName(s, name, sk)
 }
 
 // Spawn makes the Controllable passed spawn in the world.World.

--- a/server/session/session_list.go
+++ b/server/session/session_list.go
@@ -66,8 +66,11 @@ func (l *sessionList) Lookup(id uuid.UUID) (*Session, bool) {
 }
 
 func (l *sessionList) sendSessionTo(s, to *Session) {
-	runtimeID := uint64(selfEntityRuntimeID)
+	s.entityMutex.RLock()
+	name := s.name
+	s.entityMutex.RUnlock()
 
+	runtimeID := uint64(selfEntityRuntimeID)
 	to.entityMutex.Lock()
 	if s != to {
 		to.currentEntityRuntimeID += 1
@@ -79,14 +82,45 @@ func (l *sessionList) sendSessionTo(s, to *Session) {
 
 	to.writePacket(&packet.PlayerList{
 		ActionType: packet.PlayerListActionAdd,
-		Entries: []protocol.PlayerListEntry{{
-			UUID:           s.ent.UUID(),
-			EntityUniqueID: int64(runtimeID),
-			Username:       s.conn.IdentityData().DisplayName,
-			XUID:           s.conn.IdentityData().XUID,
-			Skin:           skinToProtocol(s.joinSkin),
-		}},
+		Entries:    []protocol.PlayerListEntry{playerListEntry(s, runtimeID, name, s.joinSkin)},
 	})
+}
+
+// UpdateName changes the player list name of a session and resends its entry to
+// every session so the new name is shown on the pause screen. The current skin
+// is resent with it to avoid reverting a skin changed during the session.
+func (l *sessionList) UpdateName(s *Session, name string, sk skin.Skin) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	s.entityMutex.Lock()
+	s.name = name
+	s.entityMutex.Unlock()
+
+	for _, to := range l.s {
+		to.entityMutex.RLock()
+		runtimeID, ok := to.entityRuntimeIDs[s.ent]
+		to.entityMutex.RUnlock()
+		if !ok {
+			continue
+		}
+		to.writePacket(&packet.PlayerList{
+			ActionType: packet.PlayerListActionAdd,
+			Entries:    []protocol.PlayerListEntry{playerListEntry(s, runtimeID, name, sk)},
+		})
+	}
+}
+
+// playerListEntry builds the player list entry of a session, with the name and
+// skin passed, as shown to a recipient that holds the runtime ID passed.
+func playerListEntry(s *Session, runtimeID uint64, name string, sk skin.Skin) protocol.PlayerListEntry {
+	return protocol.PlayerListEntry{
+		UUID:           s.ent.UUID(),
+		EntityUniqueID: int64(runtimeID),
+		Username:       name,
+		XUID:           s.conn.IdentityData().XUID,
+		Skin:           skinToProtocol(sk),
+	}
 }
 
 func (l *sessionList) unsendSessionFrom(s, from *Session) {


### PR DESCRIPTION
Adds a settable name for the player list on the pause/tab screen (#1083), distinct from the above-head name tag.

### API

- `Player.SetPlayerListName(name string)` / `Player.PlayerListName() string`

It defaults to the connection's display name, so existing behaviour is unchanged, and `SetNameTag` (the above-head tag) is unaffected — mirroring that method's own documentation.

### Implementation

The session stores the name (guarded by `entityMutex`) and `sessionList.UpdateName` resends the player's `PlayerListActionAdd` entry to every session — including the player itself — using each recipient's own runtime ID for the player. The player's **current** skin is resent with the entry rather than the frozen join skin, so changing the name does not revert a skin changed during the session.

Closes #1083.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
