### PR TITLE
server/player: Resync the inventory when a released item consumes nothing

### DIFF
--- a/server/player/player.go
+++ b/server/player/player.go
@@ -1583,6 +1583,7 @@ func (p *Player) UseItem() {
 func (p *Player) ReleaseItem() {
 	if !p.usingItem || !p.canRelease() || !p.GameMode().AllowsInteraction() {
 		p.usingItem = false
+		p.resyncInventory()
 		return
 	}
 	p.usingItem = false
@@ -1591,11 +1592,24 @@ func (p *Player) ReleaseItem() {
 	i, _ := p.HeldItems()
 	ctx := event.C(p)
 	if p.Handler().HandleItemRelease(ctx, i, dur); ctx.Cancelled() {
+		p.resyncInventory()
 		return
 	}
 	i.Item().(item.Releasable).Release(p, p.tx, useCtx, dur)
 	p.handleUseContext(useCtx)
+	if len(useCtx.ConsumedItems) == 0 {
+		// Nothing was consumed, so revert the item the client predicted the release would use.
+		p.resyncInventory()
+	}
 	p.updateState()
+}
+
+// resyncInventory resends the inventory to revert a release the client predicted but the server did not
+// carry out. A consumed item already updates the client through its inventory slot change.
+func (p *Player) resyncInventory() {
+	if s := p.session(); s != session.Nop {
+		s.ResyncInventory()
+	}
 }
 
 // canRelease returns whether the player can release the item currently held in the main hand.

--- a/server/session/player.go
+++ b/server/session/player.go
@@ -222,6 +222,13 @@ func (s *Session) sendArmourTrimData() {
 	s.writePacket(&packet.TrimData{Patterns: trimPatterns, Materials: trimMaterials})
 }
 
+// ResyncInventory resends the main and off-hand inventories to the client. It reverts a client-side
+// prediction the server did not carry out, such as an arrow a released bow did not consume.
+func (s *Session) ResyncInventory() {
+	s.sendInv(s.inv, protocol.WindowIDInventory)
+	s.sendInv(s.offHand, protocol.WindowIDOffHand)
+}
+
 // sendInv sends the inventory passed to the client with the window ID.
 func (s *Session) sendInv(inv *inventory.Inventory, windowID uint32) {
 	pk := &packet.InventoryContent{


### PR DESCRIPTION
Reworked fix for #1001 (the previous attempt, #1281, was closed after review).

### Problem
When a bow is released the client predicts removing an arrow. Server-side the arrow is consumed through `inventory.RemoveItem`, whose slot-change callback already resends the affected slot on every successful shot. The desync happens **only** on the paths that consume nothing — the release is cancelled, drawn for < 3 ticks, force < 0.1, or there are no arrows — where no slot changes and the client's predicted removal is never reverted.

### Fix
Resync the inventory (main + off-hand) **only on those no-consume paths** in `Player.ReleaseItem`, leaving a successful release to the existing slot-change callback. This avoids the redundant full resend / one-frame flicker that resending *before* the release caused on every shot (the concern raised on #1281 by @FDUTCH).

Closes #1001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
