### PR TITLE
block: guard zero-value smelter experience

### DIFF
--- a/server/block/smelter.go
+++ b/server/block/smelter.go
@@ -119,8 +119,12 @@ func (s *smelter) Durations() (remaining time.Duration, max time.Duration, cook 
 	return s.remainingDuration, s.maxDuration, s.cookDuration
 }
 
-// Experience returns the collected experience of the smelter.
+// Experience returns the collected experience of the smelter. Zero-value
+// smelter blocks, such as those decoded from a chunk palette, have none.
 func (s *smelter) Experience() int {
+	if s == nil {
+		return 0
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.experience


### PR DESCRIPTION
## Summary

Guard `smelter.Experience` against nil receivers so zero-value furnace, blast furnace, and smoker block values report no stored XP instead of panicking when their `BreakInfo` is computed.

Zero-value smelter blocks can appear as stateless block registry or palette values. Initializing those prototypes with `newSmelter` would give shared mutable inventory state to the registered block value, so treating missing smelter state as zero stored XP keeps the stateful data on decoded block entities.

## Validation

- Reproduced the upstream panic locally with a temporary test against `block.Furnace{}`, `block.BlastFurnace{}`, and `block.Smoker{}` calling `BreakInfo().XPDrops`.
- Verified the same temporary test passes after the fix, then removed it from the branch as requested.
- `go test ./server/... -count=1`