### PR TITLE
Validate entity registry config during creation

### DIFF
--- a/server/world/entity.go
+++ b/server/world/entity.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"maps"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -400,6 +401,9 @@ type ArrowSpawnConfig struct {
 
 // New creates an EntityRegistry using conf and the EntityTypes passed.
 func (conf EntityRegistryConfig) New(ent []EntityType) EntityRegistry {
+	if len(ent) != 0 {
+		conf.validate()
+	}
 	m := make(map[string]EntityType, len(ent))
 	for _, e := range ent {
 		name := e.EncodeEntity()
@@ -409,6 +413,35 @@ func (conf EntityRegistryConfig) New(ent []EntityType) EntityRegistry {
 		m[name] = e
 	}
 	return EntityRegistry{conf: conf, ent: m}
+}
+
+func (conf EntityRegistryConfig) validate() {
+	checks := []struct {
+		name string
+		ok   bool
+	}{
+		{name: "Item", ok: conf.Item != nil},
+		{name: "FallingBlock", ok: conf.FallingBlock != nil},
+		{name: "TNT", ok: conf.TNT != nil},
+		{name: "BottleOfEnchanting", ok: conf.BottleOfEnchanting != nil},
+		{name: "Arrow", ok: conf.Arrow != nil},
+		{name: "Egg", ok: conf.Egg != nil},
+		{name: "EnderPearl", ok: conf.EnderPearl != nil},
+		{name: "Firework", ok: conf.Firework != nil},
+		{name: "LingeringPotion", ok: conf.LingeringPotion != nil},
+		{name: "Snowball", ok: conf.Snowball != nil},
+		{name: "SplashPotion", ok: conf.SplashPotion != nil},
+		{name: "Lightning", ok: conf.Lightning != nil},
+	}
+	var missing []string
+	for _, check := range checks {
+		if !check.ok {
+			missing = append(missing, check.name)
+		}
+	}
+	if len(missing) != 0 {
+		panic("world: incomplete entity registry config: missing " + strings.Join(missing, ", "))
+	}
 }
 
 // Config returns the EntityRegistryConfig that was used to create the

--- a/server/world/weather.go
+++ b/server/world/weather.go
@@ -207,9 +207,6 @@ func (w weather) tickLightning(tx *Tx) {
 // near the lightning strike. If there is no rain at the final position
 // selected, the lightning strike will fail.
 func (w weather) strikeLightning(tx *Tx, c ChunkPos) {
-	if w.w.conf.Entities.conf.Lightning == nil {
-		return
-	}
 	if pos := w.lightningPosition(tx, c); tx.ThunderingAt(cube.PosFromVec3(pos)) {
 		tx.AddEntity(w.w.conf.Entities.conf.Lightning(EntitySpawnOpts{Position: pos}))
 	}


### PR DESCRIPTION
## Summary
- Validate `EntityRegistryConfig` when creating an `EntityRegistry` with registered entity types.
- Panic immediately if the registry config is missing any required behaviour factory functions.
- Remove the lightning nil guard so lightning follows the same registry-construction validation contract as the other entity-spawning behaviours.

## Root cause
Several behaviours read exported factory fields from `World().EntityRegistry().Config()` and invoke them directly. A custom entity registry with registered entity types but an empty factory config could therefore panic later when throwing projectiles such as ender pearls or potions.

## Validation
- `go test ./...`

No new tests added per request.