### PR TITLE
server/world: Region-based ticking with parallel tick work gathering

### DIFF
--- a/server/world/conf.go
+++ b/server/world/conf.go
@@ -3,6 +3,7 @@ package world
 import (
 	"log/slog"
 	"math/rand/v2"
+	"runtime"
 	"time"
 )
 
@@ -55,6 +56,12 @@ type Config struct {
 	// will stop random ticking altogether, while setting it higher results in
 	// faster ticking.
 	RandomTickSpeed int
+	// TickWorkers is the maximum number of goroutines used to scan loaded
+	// chunks for block ticking work each tick. The scan is read-only and all
+	// block updates still run on the world's owner goroutine, so user code
+	// never observes concurrency. 0 defaults to the CPU core count, negative
+	// values disable the extra goroutines.
+	TickWorkers int
 	// RandSource is the rand.Source used for generation of random numbers in a
 	// World, such as when selecting blocks to tick or when deciding where to
 	// strike lightning. If set to nil, RandSource defaults to a `rand.PCG`
@@ -112,6 +119,11 @@ func (conf Config) New() *World {
 	}
 	if conf.RandomTickSpeed == 0 {
 		conf.RandomTickSpeed = 3
+	}
+	if conf.TickWorkers == 0 {
+		conf.TickWorkers = runtime.GOMAXPROCS(0)
+	} else if conf.TickWorkers < 1 {
+		conf.TickWorkers = 1
 	}
 	if conf.Blocks == nil {
 		conf.Blocks = DefaultBlockRegistry

--- a/server/world/tick.go
+++ b/server/world/tick.go
@@ -123,23 +123,21 @@ func (t ticker) performNeighbourUpdates(tx *Tx) {
 	}
 }
 
-// tickBlocksRandomly executes random block ticks in loaded chunks within range of loaders.
+// tickBlocksRandomly executes random block ticks in loaded chunks within range of loaders. The read-only
+// chunk scan is gathered in parallel per tick region; all block callbacks run on the owner afterwards.
 func (t ticker) tickBlocksRandomly(tx *Tx, loaders []*Loader, tick int64) {
-	var (
-		r             = int32(tx.World().tickRange())
-		g             randUint4
-		blockEntities []cube.Pos
-		randomBlocks  []cube.Pos
-	)
+	w := tx.World()
+	r := int32(w.tickRange())
 	if r == 0 {
 		// NOP if the simulation distance is 0.
 		return
 	}
 
-	loaded := make([]ChunkPos, 0, len(loaders))
-	if tx.World().conf.Synchronous {
-		loaded = slices.Collect(maps.Keys(tx.World().chunks))
-	} else {
+	// Synchronous worlds tick all loaded chunks, regardless of loaders.
+	all := w.conf.Synchronous
+	var loaded []ChunkPos
+	if !all {
+		loaded = make([]ChunkPos, 0, len(loaders))
 		for _, loader := range loaders {
 			loader.mu.RLock()
 			pos := loader.pos
@@ -147,22 +145,77 @@ func (t ticker) tickBlocksRandomly(tx *Tx, loaders []*Loader, tick int64) {
 
 			loaded = append(loaded, pos)
 		}
+		if len(loaded) == 0 {
+			// Without loaders, no chunk can be within simulation distance.
+			return
+		}
 	}
 
-	for pos, c := range tx.World().chunks {
-		if !t.anyWithinDistance(pos, loaded, r) {
+	n := 0
+	for _, reg := range w.tickRegions.all(w.chunks) {
+		state := regionIn
+		if !all {
+			if state = reg.rangeState(loaded, r); state == regionOut {
+				// The whole region is out of simulation distance of every loader.
+				continue
+			}
+		}
+		for chunks := range slices.Chunk(reg.chunks, regionBatchSize) {
+			if n == len(w.tickBatches) {
+				w.tickBatches = append(w.tickBatches, tickBatch{})
+			}
+			b := &w.tickBatches[n]
+			n++
+			b.chunks, b.checkRange = chunks, state == regionPartial
+			b.blockEntities, b.randomBlocks = b.blockEntities[:0], b.randomBlocks[:0]
+			// Seeding batches serially up front keeps results deterministic regardless of scheduling.
+			b.pcg.Seed(w.r.Uint64(), w.r.Uint64())
+		}
+	}
+	// Drop chunk references held by scratch batches unused this tick.
+	for i := n; i < len(w.tickBatches); i++ {
+		w.tickBatches[i].chunks = nil
+	}
+	batches := w.tickBatches[:n]
+
+	runTickJobs(w.conf.TickWorkers, batches, func(b *tickBatch) {
+		t.gatherTickCandidates(w, b, loaded, r)
+	})
+
+	for i := range batches {
+		for _, pos := range batches[i].randomBlocks {
+			if rb, ok := tx.Block(pos).(RandomTicker); ok {
+				rb.RandomTick(pos, tx, w.r)
+			}
+		}
+	}
+	for i := range batches {
+		for _, pos := range batches[i].blockEntities {
+			if tb, ok := tx.Block(pos).(TickerBlock); ok {
+				tb.Tick(tick, pos, tx)
+			}
+		}
+	}
+}
+
+// gatherTickCandidates scans a batch's chunks for random tick candidates and ticking block entities. It
+// runs concurrently with other batches and must only read World state, never mutate it.
+func (t ticker) gatherTickCandidates(w *World, b *tickBatch, loaded []ChunkPos, r int32) {
+	var g randUint4
+	for _, rc := range b.chunks {
+		if b.checkRange && !t.anyWithinDistance(rc.pos, loaded, r) {
 			// No loaders in this chunk that are within the simulation distance, so proceed to the next.
 			continue
 		}
-		blockEntities = append(blockEntities, slices.Collect(maps.Keys(c.BlockEntities))...)
+		b.blockEntities = slices.AppendSeq(b.blockEntities, maps.Keys(rc.col.BlockEntities))
 
-		cx, cz := int(pos[0]<<4), int(pos[1]<<4)
+		cx, cz := int(rc.pos[0]<<4), int(rc.pos[1]<<4)
 
 		// We generate up to j random positions for every sub chunk.
-		for j := 0; j < tx.World().conf.RandomTickSpeed; j++ {
-			x, y, z := g.uint4(tx.World().r), g.uint4(tx.World().r), g.uint4(tx.World().r)
+		for j := 0; j < w.conf.RandomTickSpeed; j++ {
+			x, y, z := g.uint4(&b.pcg), g.uint4(&b.pcg), g.uint4(&b.pcg)
 
-			for i, sub := range c.Sub() {
+			for i, sub := range rc.col.Sub() {
 				if sub.Empty() {
 					// SubChunk is empty, so skip it right away.
 					continue
@@ -170,26 +223,15 @@ func (t ticker) tickBlocksRandomly(tx *Tx, loaders []*Loader, tick int64) {
 				// Generally we would want to make sure the block has its block entities, but provided blocks
 				// with block entities are generally ticked already, we are safe to assume that blocks
 				// implementing the RandomTicker don't rely on additional block entity data.
-				if rid := sub.Layers()[0].At(x, y, z); tx.World().conf.Blocks.RandomTickBlock(rid) {
-					subY := (i + (tx.Range().Min() >> 4)) << 4
-					randomBlocks = append(randomBlocks, cube.Pos{cx + int(x), subY + int(y), cz + int(z)})
+				if rid := sub.Layers()[0].At(x, y, z); w.conf.Blocks.RandomTickBlock(rid) {
+					subY := (i + (w.ra.Min() >> 4)) << 4
+					b.randomBlocks = append(b.randomBlocks, cube.Pos{cx + int(x), subY + int(y), cz + int(z)})
 
 					// Only generate new coordinates if a tickable block was actually found. If not, we can just re-use
 					// the coordinates for the next sub chunk.
-					x, y, z = g.uint4(tx.World().r), g.uint4(tx.World().r), g.uint4(tx.World().r)
+					x, y, z = g.uint4(&b.pcg), g.uint4(&b.pcg), g.uint4(&b.pcg)
 				}
 			}
-		}
-	}
-
-	for _, pos := range randomBlocks {
-		if rb, ok := tx.Block(pos).(RandomTicker); ok {
-			rb.RandomTick(pos, tx, tx.World().r)
-		}
-	}
-	for _, pos := range blockEntities {
-		if tb, ok := tx.Block(pos).(TickerBlock); ok {
-			tb.Tick(tick, pos, tx)
 		}
 	}
 }
@@ -266,9 +308,9 @@ type randUint4 struct {
 }
 
 // uint4 returns a random uint4.
-func (g *randUint4) uint4(r *rand.Rand) uint8 {
+func (g *randUint4) uint4(src rand.Source) uint8 {
 	if g.n == 0 {
-		g.x = r.Uint64()
+		g.x = src.Uint64()
 		g.n = 16
 	}
 	val := g.x & 0b1111

--- a/server/world/tick_region.go
+++ b/server/world/tick_region.go
@@ -1,0 +1,339 @@
+package world
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"runtime/debug"
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	"github.com/df-mc/dragonfly/server/block/cube"
+)
+
+// This file implements region-based ticking, inspired by Folia's threaded
+// regions: loaded chunks are partitioned into clusters that are more than
+// 8 chunks apart. Each tick, the read-only scan for block tick candidates
+// runs over these regions on worker goroutines while the owner goroutine
+// waits. All block callbacks then run on the owner as usual, so the
+// transaction model is unaffected.
+
+const (
+	// regionCellShift is the power of two of the width, in chunks, of the grid
+	// cells used to cluster chunks: chunks in the same or adjacent cells always
+	// share a region.
+	regionCellShift = 3
+	// regionBatchSize is the maximum number of chunks per gather job, so that
+	// one big region still spreads across all tick workers.
+	regionBatchSize = 64
+)
+
+// regionCell is the position of a region grid cell.
+type regionCell [2]int32
+
+// cellOf returns the region grid cell containing a chunk position.
+func cellOf(pos ChunkPos) regionCell {
+	return regionCell{pos[0] >> regionCellShift, pos[1] >> regionCellShift}
+}
+
+// cmpChunkPos orders chunk positions by x, then z.
+func cmpChunkPos(a, b ChunkPos) int {
+	if a[0] != b[0] {
+		return int(a[0]) - int(b[0])
+	}
+	return int(a[1]) - int(b[1])
+}
+
+// tickRegion is a cluster of loaded chunks spatially independent of all other
+// regions of the same World.
+type tickRegion struct {
+	chunks []regionChunk // sorted by position
+	// min and max hold the region's bounding box in chunk coordinates. It may
+	// overestimate after chunk removals, which only makes range checks more
+	// conservative.
+	min, max ChunkPos
+}
+
+// regionChunk is a single loaded chunk within a tickRegion.
+type regionChunk struct {
+	pos ChunkPos
+	col *Column
+}
+
+// insert adds a chunk to the region, keeping chunks sorted and the bounding
+// box up to date.
+func (reg *tickRegion) insert(pos ChunkPos, col *Column) {
+	i, _ := slices.BinarySearchFunc(reg.chunks, pos, func(rc regionChunk, p ChunkPos) int { return cmpChunkPos(rc.pos, p) })
+	reg.chunks = slices.Insert(reg.chunks, i, regionChunk{pos: pos, col: col})
+	reg.min[0], reg.min[1] = min(reg.min[0], pos[0]), min(reg.min[1], pos[1])
+	reg.max[0], reg.max[1] = max(reg.max[0], pos[0]), max(reg.max[1], pos[1])
+}
+
+// remove deletes a chunk from the region. The bounding box is left unchanged.
+func (reg *tickRegion) remove(pos ChunkPos) {
+	if i, ok := slices.BinarySearchFunc(reg.chunks, pos, func(rc regionChunk, p ChunkPos) int { return cmpChunkPos(rc.pos, p) }); ok {
+		reg.chunks = slices.Delete(reg.chunks, i, i+1)
+	}
+}
+
+// Range classifications of a region relative to the loaders' positions.
+const (
+	regionOut = iota
+	regionPartial
+	regionIn
+)
+
+// rangeState reports whether the region is fully outside simulation distance
+// r of all loaded positions, fully inside it for at least one, or partial.
+func (reg *tickRegion) rangeState(loaded []ChunkPos, r int32) int {
+	state := regionOut
+	for _, pos := range loaded {
+		dx := max(reg.min[0]-pos[0], 0, pos[0]-reg.max[0])
+		dz := max(reg.min[1]-pos[1], 0, pos[1]-reg.max[1])
+		if dx*dx+dz*dz > r*r {
+			continue
+		}
+		// Within range of the near side; if the far corner is in range too,
+		// every chunk of the region is within distance of this loader.
+		fx := max(pos[0]-reg.min[0], reg.max[0]-pos[0])
+		fz := max(pos[1]-reg.min[1], reg.max[1]-pos[1])
+		if fx*fx+fz*fz <= r*r {
+			return regionIn
+		}
+		state = regionPartial
+	}
+	return state
+}
+
+// regionPartition maintains the division of a World's loaded chunks into tick
+// regions, updated incrementally as chunks load and unload. It must only be
+// used from the World's owner goroutine.
+type regionPartition struct {
+	regions []*tickRegion // sorted by first chunk position
+	cells   map[regionCell]*tickRegion
+	counts  map[regionCell]int
+	total   int
+	dirty   bool
+}
+
+// markDirty schedules a full rebuild and releases all cached chunk references
+// so unloaded chunks are not kept in memory until the next tick.
+func (p *regionPartition) markDirty() {
+	p.regions, p.cells, p.counts, p.total, p.dirty = nil, nil, nil, 0, true
+}
+
+// addChunk inserts a loaded chunk into the partition. A chunk in a cell that
+// borders multiple regions merges them; a chunk in a free-standing cell forms
+// a new region.
+func (p *regionPartition) addChunk(pos ChunkPos, col *Column) {
+	if p.dirty {
+		return
+	}
+	if p.cells == nil {
+		p.markDirty()
+		return
+	}
+	cell := cellOf(pos)
+	reg, ok := p.cells[cell]
+	if !ok {
+		var neighbours []*tickRegion
+		for dx := int32(-1); dx <= 1; dx++ {
+			for dz := int32(-1); dz <= 1; dz++ {
+				if n, ok := p.cells[regionCell{cell[0] + dx, cell[1] + dz}]; ok && !slices.Contains(neighbours, n) {
+					neighbours = append(neighbours, n)
+				}
+			}
+		}
+		switch len(neighbours) {
+		case 0:
+			reg = &tickRegion{min: pos, max: pos}
+			p.regions = append(p.regions, reg)
+		case 1:
+			reg = neighbours[0]
+		default:
+			reg = p.merge(neighbours)
+		}
+		p.cells[cell] = reg
+	}
+	reg.insert(pos, col)
+	p.counts[cell]++
+	p.total++
+	p.sortRegions()
+}
+
+// removeChunk removes an unloaded chunk from the partition. Emptying a cell
+// may split a region, so that case falls back to a full rebuild.
+func (p *regionPartition) removeChunk(pos ChunkPos) {
+	if p.dirty {
+		return
+	}
+	cell := cellOf(pos)
+	reg, ok := p.cells[cell]
+	if !ok || p.counts[cell] == 1 {
+		p.markDirty()
+		return
+	}
+	reg.remove(pos)
+	p.counts[cell]--
+	p.total--
+	p.sortRegions()
+}
+
+// merge joins multiple regions into the first one, remapping their cells.
+func (p *regionPartition) merge(regions []*tickRegion) *tickRegion {
+	target := regions[0]
+	for _, reg := range regions[1:] {
+		target.chunks = append(target.chunks, reg.chunks...)
+		target.min[0], target.min[1] = min(target.min[0], reg.min[0]), min(target.min[1], reg.min[1])
+		target.max[0], target.max[1] = max(target.max[0], reg.max[0]), max(target.max[1], reg.max[1])
+	}
+	slices.SortFunc(target.chunks, func(a, b regionChunk) int { return cmpChunkPos(a.pos, b.pos) })
+	for cell, reg := range p.cells {
+		if slices.Contains(regions[1:], reg) {
+			p.cells[cell] = target
+		}
+	}
+	p.regions = slices.DeleteFunc(p.regions, func(reg *tickRegion) bool { return slices.Contains(regions[1:], reg) })
+	return target
+}
+
+// sortRegions restores the deterministic region order. Chunk positions are
+// unique, so regions' first chunks give a total order.
+func (p *regionPartition) sortRegions() {
+	slices.SortFunc(p.regions, func(a, b *tickRegion) int { return cmpChunkPos(a.chunks[0].pos, b.chunks[0].pos) })
+}
+
+// all returns the tick regions for the chunks passed, rebuilding the
+// partition if it is dirty or inconsistent with the chunk map.
+func (p *regionPartition) all(chunks map[ChunkPos]*Column) []*tickRegion {
+	if p.dirty || p.cells == nil || p.total != len(chunks) {
+		p.rebuild(chunks)
+	}
+	return p.regions
+}
+
+// rebuild recomputes the partition from scratch with a union-find over the
+// region cell grid, merging cells that touch, including diagonally.
+func (p *regionPartition) rebuild(chunks map[ChunkPos]*Column) {
+	parent := make(map[regionCell]regionCell)
+	var find func(c regionCell) regionCell
+	find = func(c regionCell) regionCell {
+		pr := parent[c]
+		if pr == c {
+			return c
+		}
+		root := find(pr)
+		parent[c] = root
+		return root
+	}
+
+	counts := make(map[regionCell]int)
+	for pos := range chunks {
+		cell := cellOf(pos)
+		counts[cell]++
+		if _, ok := parent[cell]; !ok {
+			parent[cell] = cell
+		}
+	}
+	for cell := range parent {
+		for dx := int32(-1); dx <= 1; dx++ {
+			for dz := int32(-1); dz <= 1; dz++ {
+				n := regionCell{cell[0] + dx, cell[1] + dz}
+				if _, ok := parent[n]; ok {
+					if ra, rb := find(cell), find(n); ra != rb {
+						parent[ra] = rb
+					}
+				}
+			}
+		}
+	}
+
+	roots := make(map[regionCell]*tickRegion)
+	cells := make(map[regionCell]*tickRegion, len(parent))
+	var regions []*tickRegion
+	for pos, col := range chunks {
+		cell := cellOf(pos)
+		root := find(cell)
+		reg, ok := roots[root]
+		if !ok {
+			reg = &tickRegion{min: pos, max: pos}
+			roots[root] = reg
+			regions = append(regions, reg)
+		}
+		cells[cell] = reg
+		reg.min[0], reg.min[1] = min(reg.min[0], pos[0]), min(reg.min[1], pos[1])
+		reg.max[0], reg.max[1] = max(reg.max[0], pos[0]), max(reg.max[1], pos[1])
+		reg.chunks = append(reg.chunks, regionChunk{pos: pos, col: col})
+	}
+	for _, reg := range regions {
+		slices.SortFunc(reg.chunks, func(a, b regionChunk) int { return cmpChunkPos(a.pos, b.pos) })
+	}
+
+	p.regions, p.cells, p.counts, p.total, p.dirty = regions, cells, counts, len(chunks), false
+	p.sortRegions()
+}
+
+// tickBatch is one unit of gather work: a slice of one region's chunks with a
+// batch-local random source and the output buffers filled by its worker.
+// Batches are owned by the World and reused across ticks.
+type tickBatch struct {
+	chunks     []regionChunk
+	pcg        rand.PCG
+	checkRange bool
+
+	blockEntities []cube.Pos
+	randomBlocks  []cube.Pos
+}
+
+// workerPanic wraps a panic that occurred on a tick worker together with the
+// worker's stack trace, so re-raising it on the owner stays diagnosable.
+type workerPanic struct {
+	value any
+	stack []byte
+}
+
+func (p *workerPanic) Error() string {
+	return fmt.Sprintf("tick worker: %v\n\nworker goroutine stack:\n%s", p.value, p.stack)
+}
+
+// runTickJobs runs fn for every batch on up to workers goroutines and blocks
+// until all have completed. The workers only synchronise through a WaitGroup,
+// so the call cannot deadlock; a worker panic is re-raised on the caller.
+func runTickJobs(workers int, batches []tickBatch, fn func(b *tickBatch)) {
+	if workers > len(batches) {
+		workers = len(batches)
+	}
+	if workers <= 1 {
+		for i := range batches {
+			fn(&batches[i])
+		}
+		return
+	}
+	var (
+		next     atomic.Int64
+		panicked atomic.Pointer[workerPanic]
+		wg       sync.WaitGroup
+	)
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if v := recover(); v != nil {
+					panicked.CompareAndSwap(nil, &workerPanic{value: v, stack: debug.Stack()})
+				}
+			}()
+			for {
+				i := int(next.Add(1)) - 1
+				if i >= len(batches) {
+					return
+				}
+				fn(&batches[i])
+			}
+		}()
+	}
+	wg.Wait()
+	if v := panicked.Load(); v != nil {
+		panic(v)
+	}
+}

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -64,6 +64,12 @@ type World struct {
 	// from this map after some time of not being used.
 	chunks map[ChunkPos]*Column
 
+	// tickRegions maintains the partition of loaded chunks into tick regions,
+	// updated whenever the chunks map gains or loses a chunk. tickBatches is
+	// scratch space for the per-tick gather jobs, reused across ticks.
+	tickRegions regionPartition
+	tickBatches []tickBatch
+
 	// entities holds a map of entities currently loaded and the last ChunkPos
 	// that the Entity was in. These are tracked so that a call to RemoveEntity
 	// can find the correct Entity.
@@ -1173,6 +1179,7 @@ func (w *World) closeChunk(tx *Tx, pos ChunkPos, c *Column) {
 	}
 	clear(c.Entities)
 	delete(w.chunks, pos)
+	w.tickRegions.removeChunk(pos)
 }
 
 // Close closes the world and saves all chunks currently loaded.
@@ -1328,6 +1335,7 @@ func (w *World) loadChunk(pos ChunkPos) (*Column, error) {
 	case err == nil:
 		col := w.columnFrom(column, pos)
 		w.chunks[pos] = col
+		w.tickRegions.addChunk(pos, col)
 		for _, e := range col.Entities {
 			w.entities[e] = pos
 			e.setAndUnlockWorld(w)
@@ -1338,6 +1346,7 @@ func (w *World) loadChunk(pos ChunkPos) (*Column, error) {
 		// The provider doesn't have a chunk saved at this position, so we generate a new one.
 		col := newColumn(chunk.New(w.conf.Blocks, w.Range()))
 		w.chunks[pos] = col
+		w.tickRegions.addChunk(pos, col)
 
 		w.conf.Generator.GenerateChunk(pos, col.Chunk)
 		return col, nil


### PR DESCRIPTION
This PR adds region-based ticking (Folia inspired). Loaded chunks are partitioned into spatial regions. Ticks run in parallel across the regional batches up to `Config.TickWorkers` goroutines while owner goroutine waits.

All block callbacks still exec on the world's owner goroutine afterwards, so block impls and handlers are not affected.

## Benchmarks

Random tick phase with loaders spread across a grid of loaded chunks
(5 non-empty sub chunks each, 1 random-tickable block per 64), benchstat,
n=10, 16-thread machine:

| Benchmark                  | master   | this PR  | delta   |
|----------------------------|----------|----------|---------|
| TickBlocksRandomly/16x16   | 52.7µs   | 31.1µs   | −41%    |
| TickBlocksRandomly/32x32   | 101.2µs  | 43.2µs   | −57%    |
| TickBlocksRandomly/64x64   | 141.1µs  | 49.0µs   | −65%    |
| AdvanceTick/16x16 (full tick) | 65.5µs | 32.5µs  | −50%    |
| AdvanceTick/32x32 (full tick) | 316.4µs | 92.7µs | −71%    |

With `GOMAXPROCS=1` the 64×64 case still improves 141µs → ~106µs from the
region range classification alone; the rest comes from parallel gathering.

## Real-world load test

Separately load-tested on a production-style server setup: 100 server-side
bot players fighting in pairs across 10 clusters ~1km apart in one world
(~1,800 and ~7,500 loaded chunks), 90s runs, 2 runs per variant:

| Scenario      | mean tick (before → after) | p99 tick (before → after) |
|---------------|----------------------------|---------------------------|
| 1,771 chunks  | 2.16ms → 0.96ms (−55%)     | 3.04ms → 1.54ms (−49%)    |
| 7,491 chunks  | 2.88ms → 0.85ms (−70%)     | 4.25ms → 1.24ms (−71%)    |