### PR TITLE
server: fix Java explosion knockback

### DIFF
--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -97,7 +97,7 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 	for e := range tx.EntitiesWithin(box.Grow(2)) {
 		pos := e.Position()
 		dist := pos.Sub(explosionPos).Len()
-		if dist > d || dist == 0 {
+		if dist > d {
 			continue
 		}
 

--- a/server/entity/direction.go
+++ b/server/entity/direction.go
@@ -20,3 +20,12 @@ func EyePosition(e world.Entity) mgl64.Vec3 {
 	}
 	return pos
 }
+
+// ExplosionImpulse returns the velocity added to an entity by an explosion.
+func ExplosionImpulse(e world.Entity, src world.ExplosionSource, impact float64) mgl64.Vec3 {
+	direction := EyePosition(e).Sub(src.Position())
+	if direction.Len() == 0 {
+		return mgl64.Vec3{}
+	}
+	return direction.Normalize().Mul(impact)
+}

--- a/server/entity/passive.go
+++ b/server/entity/passive.go
@@ -64,7 +64,7 @@ type PassiveBehaviour struct {
 // Explode adds velocity to a passive entity to blast it away from the
 // explosion's source.
 func (p *PassiveBehaviour) Explode(e *Ent, src world.ExplosionSource, impact float64) {
-	e.data.Vel = e.data.Vel.Add(e.data.Pos.Sub(src.Position()).Normalize().Mul(impact))
+	e.data.Vel = e.data.Vel.Add(ExplosionImpulse(e, src, impact))
 }
 
 // Fuse returns the leftover time until PassiveBehaviourConfig.Expire is called,

--- a/server/entity/projectile.go
+++ b/server/entity/projectile.go
@@ -136,7 +136,7 @@ func (lt *ProjectileBehaviour) Owner() *world.EntityHandle {
 // Explode adds velocity to a projectile to blast it away from the explosion's
 // source.
 func (lt *ProjectileBehaviour) Explode(e *Ent, src world.ExplosionSource, impact float64) {
-	e.data.Vel = e.Velocity().Add(e.Position().Sub(src.Position()).Normalize().Mul(impact))
+	e.data.Vel = e.Velocity().Add(ExplosionImpulse(e, src, impact))
 }
 
 // Potion returns the potion.Potion that is applied to an entity if hit by the

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -715,10 +715,14 @@ func (p *Player) FinalDamageFrom(dmg float64, src world.DamageSource) float64 {
 
 // Explode ...
 func (p *Player) Explode(src world.ExplosionSource, impact float64) {
-	explosionPos := src.Position()
-	diff := p.Position().Sub(explosionPos)
+	// Java uses Blast Protection's explosion-specific resistance here, not innate armour knockback resistance.
+	resistance := min(float64(p.Armour().HighestEnchantmentLevel(enchantment.BlastProtection))*0.15, 1)
 	p.Hurt(math.Floor((impact*impact+impact)*3.5*src.Size()*2+1), entity.ExplosionDamageSource{Source: src})
-	p.knockBack(explosionPos, impact, diff[1]/diff.Len()*impact)
+
+	impulse := entity.ExplosionImpulse(p, src, impact*(1-resistance))
+	velocity := p.Velocity().Add(impulse)
+	p.data.Vel = velocity
+	p.SetVelocity(velocity)
 }
 
 // SetAbsorption sets the absorption health of a player. This extra health shows as golden hearts and do not


### PR DESCRIPTION
## Summary

- affect entities whose feet coincide with the explosion origin
- calculate explosion impulse from the entity eye position and add it to existing velocity
- safely handle zero-length directions for non-eyed entities
- apply Java-style Blast Protection resistance and preserve consecutive same-tick impulses

## Verification

- `go test ./...`
- `make lint`
- `codex review --uncommitted`