### PR TITLE
block: generalize secondary break drops

### DIFF
--- a/server/block/barrel.go
+++ b/server/block/barrel.go
@@ -124,10 +124,10 @@ func (b Barrel) UseOnBlock(pos cube.Pos, face cube.Face, _ mgl64.Vec3, tx *world
 
 // BreakInfo ...
 func (b Barrel) BreakInfo() BreakInfo {
-	return newBreakInfo(2.5, alwaysHarvestable, axeEffective, oneOf(b)).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
-		for _, i := range b.Inventory(tx, pos).Clear() {
-			dropItem(tx, i, pos.Vec3())
-		}
+	return newBreakInfo(2.5, alwaysHarvestable, axeEffective, oneOf(b)).withAdditionalDrops(func(pos cube.Pos, tx *world.Tx, _ item.User) []item.Stack {
+		return b.Inventory(tx, pos).Items()
+	}).withBreakHandler(func(pos cube.Pos, tx *world.Tx, _ item.User) {
+		b.Inventory(tx, pos).Clear()
 	})
 }
 

--- a/server/block/blast_furnace.go
+++ b/server/block/blast_furnace.go
@@ -84,10 +84,10 @@ func (b BlastFurnace) BreakInfo() BreakInfo {
 	if b.smelter != nil {
 		xp = b.Experience()
 	}
-	return newBreakInfo(3.5, alwaysHarvestable, pickaxeEffective, oneOf(BlastFurnace{})).withXPDropRange(xp, xp).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
-		for _, i := range b.Inventory(tx, pos).Clear() {
-			dropItem(tx, i, pos.Vec3())
-		}
+	return newBreakInfo(3.5, alwaysHarvestable, pickaxeEffective, oneOf(BlastFurnace{})).withXPDropRange(xp, xp).withAdditionalDrops(func(pos cube.Pos, tx *world.Tx, _ item.User) []item.Stack {
+		return b.Inventory(tx, pos).Items()
+	}).withBreakHandler(func(pos cube.Pos, tx *world.Tx, _ item.User) {
+		b.Inventory(tx, pos).Clear()
 	})
 }
 

--- a/server/block/break_info.go
+++ b/server/block/break_info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/df-mc/dragonfly/server/item/enchantment"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/particle"
+	"github.com/go-gl/mathgl/mgl64"
 )
 
 // Breakable represents a block that may be broken by a player in survival mode. Blocks not include are blocks
@@ -129,6 +130,14 @@ type BreakInfo struct {
 	Effective func(t item.Tool) bool
 	// Drops is a function called to get the drops of the block if it is broken using the item passed.
 	Drops func(t item.Tool, enchantments []item.Enchantment) []item.Stack
+	// AdditionalDrops is an observational function called to get drops that are not dependent on the tool used to
+	// break the block. It is called before the cancellable break event and before the block is cleared, so it must not
+	// mutate the world or the block's inventories. The user is nil when the block is broken without a player, such as
+	// by an explosion.
+	AdditionalDrops func(pos cube.Pos, tx *world.Tx, u item.User) []item.Stack
+	// AdditionalDropPosition optionally returns the position at which AdditionalDrops are spawned. It must be
+	// observational and pure. If nil, additional drops are spawned at the block centre.
+	AdditionalDropPosition func(pos cube.Pos) mgl64.Vec3
 	// BreakHandler is called after the block has broken.
 	BreakHandler func(pos cube.Pos, w *world.Tx, u item.User)
 	// XPDrops is the range of XP a block can drop when broken.
@@ -165,6 +174,18 @@ func (b BreakInfo) withBlastResistance(res float64) BreakInfo {
 // withBreakHandler sets the BreakHandler field of the BreakInfo struct to the passed value.
 func (b BreakInfo) withBreakHandler(handler func(pos cube.Pos, w *world.Tx, u item.User)) BreakInfo {
 	b.BreakHandler = handler
+	return b
+}
+
+// withAdditionalDrops sets the AdditionalDrops field of the BreakInfo struct to the function passed.
+func (b BreakInfo) withAdditionalDrops(drops func(pos cube.Pos, tx *world.Tx, u item.User) []item.Stack) BreakInfo {
+	b.AdditionalDrops = drops
+	return b
+}
+
+// withAdditionalDropPosition sets the AdditionalDropPosition field of the BreakInfo struct to the function passed.
+func (b BreakInfo) withAdditionalDropPosition(position func(pos cube.Pos) mgl64.Vec3) BreakInfo {
+	b.AdditionalDropPosition = position
 	return b
 }
 
@@ -402,11 +423,31 @@ func cropSeedDrops(seed, crop world.Item, growth int) func(item.Tool, []item.Enc
 // breakBlock removes a block, shows breaking particles and drops the drops of
 // the block as items.
 func breakBlock(b world.Block, pos cube.Pos, tx *world.Tx) {
+	breakable, ok := b.(Breakable)
+	if !ok {
+		breakBlockNoDrops(b, pos, tx)
+		return
+	}
+
+	info := breakable.BreakInfo()
+	drops := info.Drops(item.ToolNone{}, nil)
+	additionalDropCount := 0
+	if info.AdditionalDrops != nil {
+		additional := info.AdditionalDrops(pos, tx, nil)
+		additionalDropCount = len(additional)
+		drops = append(drops, additional...)
+	}
+	additionalDropPos := pos.Vec3Centre()
+	if additionalDropCount > 0 && info.AdditionalDropPosition != nil {
+		additionalDropPos = info.AdditionalDropPosition(pos)
+	}
 	breakBlockNoDrops(b, pos, tx)
-	if breakable, ok := b.(Breakable); ok {
-		for _, drop := range breakable.BreakInfo().Drops(item.ToolNone{}, nil) {
-			dropItem(tx, drop, pos.Vec3Centre())
+	for i, drop := range drops {
+		dropPos := pos.Vec3Centre()
+		if i >= len(drops)-additionalDropCount {
+			dropPos = additionalDropPos
 		}
+		dropItem(tx, drop, dropPos)
 	}
 }
 

--- a/server/block/break_info.go
+++ b/server/block/break_info.go
@@ -131,8 +131,7 @@ type BreakInfo struct {
 	// Drops is a function called to get the drops of the block if it is broken using the item passed.
 	Drops func(t item.Tool, enchantments []item.Enchantment) []item.Stack
 	// AdditionalDrops returns drops that do not depend on the tool used to break the block. It is called before the
-	// cancellable break event and before the block is cleared, so it must not change the world or any inventory. u is
-	// nil when the block is broken without a player, such as by an explosion.
+	// cancellable break event and before the block is cleared, so it must not change the world or any inventory. u is nil when the block is broken without a player, such as by an explosion.
 	AdditionalDrops func(pos cube.Pos, tx *world.Tx, u item.User) []item.Stack
 	// AdditionalDropPosition returns the position at which AdditionalDrops are spawned. If nil, they are spawned at
 	// the block centre. The function must not change the world or any inventory.

--- a/server/block/break_info.go
+++ b/server/block/break_info.go
@@ -130,13 +130,12 @@ type BreakInfo struct {
 	Effective func(t item.Tool) bool
 	// Drops is a function called to get the drops of the block if it is broken using the item passed.
 	Drops func(t item.Tool, enchantments []item.Enchantment) []item.Stack
-	// AdditionalDrops is an observational function called to get drops that are not dependent on the tool used to
-	// break the block. It is called before the cancellable break event and before the block is cleared, so it must not
-	// mutate the world or the block's inventories. The user is nil when the block is broken without a player, such as
-	// by an explosion.
+	// AdditionalDrops returns drops that do not depend on the tool used to break the block. It is called before the
+	// cancellable break event and before the block is cleared, so it must not change the world or any inventory. u is
+	// nil when the block is broken without a player, such as by an explosion.
 	AdditionalDrops func(pos cube.Pos, tx *world.Tx, u item.User) []item.Stack
-	// AdditionalDropPosition optionally returns the position at which AdditionalDrops are spawned. It must be
-	// observational and pure. If nil, additional drops are spawned at the block centre.
+	// AdditionalDropPosition returns the position at which AdditionalDrops are spawned. If nil, they are spawned at
+	// the block centre. The function must not change the world or any inventory.
 	AdditionalDropPosition func(pos cube.Pos) mgl64.Vec3
 	// BreakHandler is called after the block has broken.
 	BreakHandler func(pos cube.Pos, w *world.Tx, u item.User)

--- a/server/block/brewing_stand.go
+++ b/server/block/brewing_stand.go
@@ -114,10 +114,10 @@ func (b BrewingStand) DecodeNBT(data map[string]any) any {
 
 // BreakInfo ...
 func (b BrewingStand) BreakInfo() BreakInfo {
-	return newBreakInfo(0.5, alwaysHarvestable, pickaxeEffective, oneOf(BrewingStand{})).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
-		for _, i := range b.Inventory(tx, pos).Clear() {
-			dropItem(tx, i, pos.Vec3Centre())
-		}
+	return newBreakInfo(0.5, alwaysHarvestable, pickaxeEffective, oneOf(BrewingStand{})).withAdditionalDrops(func(pos cube.Pos, tx *world.Tx, _ item.User) []item.Stack {
+		return b.Inventory(tx, pos).Items()
+	}).withBreakHandler(func(pos cube.Pos, tx *world.Tx, _ item.User) {
+		b.Inventory(tx, pos).Clear()
 	})
 }
 

--- a/server/block/campfire.go
+++ b/server/block/campfire.go
@@ -61,12 +61,14 @@ func (c Campfire) BreakInfo() BreakInfo {
 			return []item.Stack{item.NewStack(SoulSoil{}, 1)}
 		}
 		panic("should never happen")
-	}).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
+	}).withAdditionalDrops(func(cube.Pos, *world.Tx, item.User) []item.Stack {
+		var drops []item.Stack
 		for _, v := range c.Items {
 			if !v.Item.Empty() {
-				dropItem(tx, v.Item, pos.Vec3Centre())
+				drops = append(drops, v.Item)
 			}
 		}
+		return drops
 	})
 }
 

--- a/server/block/chest.go
+++ b/server/block/chest.go
@@ -186,19 +186,27 @@ func (c Chest) UseOnBlock(pos cube.Pos, face cube.Face, _ mgl64.Vec3, tx *world.
 
 // BreakInfo ...
 func (c Chest) BreakInfo() BreakInfo {
-	return newBreakInfo(2.5, alwaysHarvestable, axeEffective, oneOf(c)).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
+	return newBreakInfo(2.5, alwaysHarvestable, axeEffective, oneOf(c)).withAdditionalDrops(func(cube.Pos, *world.Tx, item.User) []item.Stack {
+		return c.breakDrops()
+	}).withBreakHandler(func(pos cube.Pos, tx *world.Tx, _ item.User) {
 		if c.paired {
 			pairPos := c.pairPos(pos)
-			if _, pair, ok := c.unpair(tx, pos); ok {
-				c.paired = false
+			if ch, pair, ok := c.unpair(tx, pos); ok {
+				ch.Inventory(tx, pos).Clear()
 				tx.SetBlock(pairPos, pair, nil)
+				return
 			}
 		}
 
-		for _, i := range c.Inventory(tx, pos).Clear() {
-			dropItem(tx, i, pos.Vec3Centre())
-		}
+		c.Inventory(tx, pos).Clear()
 	})
+}
+
+func (c Chest) breakDrops() []item.Stack {
+	if c.inventory == nil {
+		return nil
+	}
+	return c.inventory.Items()
 }
 
 // FuelInfo ...

--- a/server/block/composter.go
+++ b/server/block/composter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/particle"
 	"github.com/df-mc/dragonfly/server/world/sound"
+	"github.com/go-gl/mathgl/mgl64"
 	"math/rand/v2"
 	"time"
 )
@@ -82,10 +83,13 @@ func (c Composter) SideClosed(cube.Pos, cube.Pos, *world.Tx) bool {
 
 // BreakInfo ...
 func (c Composter) BreakInfo() BreakInfo {
-	return newBreakInfo(0.6, alwaysHarvestable, axeEffective, oneOf(c)).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
+	return newBreakInfo(0.6, alwaysHarvestable, axeEffective, oneOf(c)).withAdditionalDrops(func(cube.Pos, *world.Tx, item.User) []item.Stack {
 		if c.Level == 8 {
-			dropItem(tx, item.NewStack(item.BoneMeal{}, 1), pos.Side(cube.FaceUp).Vec3Middle())
+			return []item.Stack{item.NewStack(item.BoneMeal{}, 1)}
 		}
+		return nil
+	}).withAdditionalDropPosition(func(pos cube.Pos) mgl64.Vec3 {
+		return pos.Side(cube.FaceUp).Vec3Middle()
 	})
 }
 

--- a/server/block/decorated_pot.go
+++ b/server/block/decorated_pot.go
@@ -40,6 +40,10 @@ func (p DecoratedPot) SideClosed(cube.Pos, cube.Pos, *world.Tx) bool {
 
 // ProjectileHit ...
 func (p DecoratedPot) ProjectileHit(pos cube.Pos, tx *world.Tx, _ world.Entity, _ cube.Face) {
+	var drops []item.Stack
+	if extra := p.BreakInfo().AdditionalDrops; extra != nil {
+		drops = extra(pos, tx, nil)
+	}
 	for _, d := range p.Decorations {
 		if d == nil {
 			dropItem(tx, item.NewStack(item.Brick{}, 1), pos.Vec3Centre())
@@ -48,6 +52,9 @@ func (p DecoratedPot) ProjectileHit(pos cube.Pos, tx *world.Tx, _ world.Entity, 
 		dropItem(tx, item.NewStack(d, 1), pos.Vec3Centre())
 	}
 	breakBlockNoDrops(p, pos, tx)
+	for _, drop := range drops {
+		dropItem(tx, drop, pos.Vec3Centre())
+	}
 }
 
 // Pick ...
@@ -120,10 +127,11 @@ func (p DecoratedPot) Activate(pos cube.Pos, _ cube.Face, tx *world.Tx, u item.U
 
 // BreakInfo ...
 func (p DecoratedPot) BreakInfo() BreakInfo {
-	return newBreakInfo(0, alwaysHarvestable, nothingEffective, oneOf(DecoratedPot{Decorations: p.Decorations})).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
+	return newBreakInfo(0, alwaysHarvestable, nothingEffective, oneOf(DecoratedPot{Decorations: p.Decorations})).withAdditionalDrops(func(cube.Pos, *world.Tx, item.User) []item.Stack {
 		if !p.Item.Empty() {
-			dropItem(tx, p.Item, pos.Vec3Centre())
+			return []item.Stack{p.Item}
 		}
+		return nil
 	})
 }
 

--- a/server/block/explosion.go
+++ b/server/block/explosion.go
@@ -187,15 +187,31 @@ func (c ExplosionConfig) Explode(tx *world.Tx, src world.ExplosionSource) {
 		if explodable, ok := bl.(Explodable); ok {
 			explodable.Explode(src, pos, tx)
 		} else if breakable, ok := bl.(Breakable); ok {
+			info := breakable.BreakInfo()
+			var additionalDrops []item.Stack
+			if info.AdditionalDrops != nil {
+				additionalDrops = info.AdditionalDrops(pos, tx, nil)
+			}
 			// Clear the block first so break handlers see the post-break world, this is required by things such as redstone updates.
 			tx.SetBlock(pos, nil, nil)
-			breakHandler := breakable.BreakInfo().BreakHandler
+			breakHandler := info.BreakHandler
 			if breakHandler != nil {
 				breakHandler(pos, tx, nil)
 			}
 			if itemDropChance > r.Float64() {
-				for _, drop := range breakable.BreakInfo().Drops(item.ToolNone{}, nil) {
+				for _, drop := range info.Drops(item.ToolNone{}, nil) {
 					dropItem(tx, drop, pos.Vec3Centre())
+				}
+			}
+			// Additional drops are independent of the ordinary harvest-drop chance. A negative chance remains the
+			// documented explicit setting that suppresses all item drops.
+			if itemDropChance >= 0 {
+				additionalDropPos := pos.Vec3Centre()
+				if len(additionalDrops) > 0 && info.AdditionalDropPosition != nil {
+					additionalDropPos = info.AdditionalDropPosition(pos)
+				}
+				for _, drop := range additionalDrops {
+					dropItem(tx, drop, additionalDropPos)
 				}
 			}
 		}

--- a/server/block/furnace.go
+++ b/server/block/furnace.go
@@ -83,10 +83,10 @@ func (f Furnace) BreakInfo() BreakInfo {
 	if f.smelter != nil {
 		xp = f.Experience()
 	}
-	return newBreakInfo(3.5, alwaysHarvestable, pickaxeEffective, oneOf(Furnace{})).withXPDropRange(xp, xp).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
-		for _, i := range f.Inventory(tx, pos).Clear() {
-			dropItem(tx, i, pos.Vec3())
-		}
+	return newBreakInfo(3.5, alwaysHarvestable, pickaxeEffective, oneOf(Furnace{})).withXPDropRange(xp, xp).withAdditionalDrops(func(pos cube.Pos, tx *world.Tx, _ item.User) []item.Stack {
+		return f.Inventory(tx, pos).Items()
+	}).withBreakHandler(func(pos cube.Pos, tx *world.Tx, _ item.User) {
+		f.Inventory(tx, pos).Clear()
 	})
 }
 

--- a/server/block/hopper.go
+++ b/server/block/hopper.go
@@ -72,10 +72,10 @@ func (Hopper) CanRedstoneWireStepDown(cube.Pos, cube.Pos, *world.Tx) bool {
 
 // BreakInfo ...
 func (h Hopper) BreakInfo() BreakInfo {
-	return newBreakInfo(3, pickaxeHarvestable, pickaxeEffective, oneOf(Hopper{})).withBlastResistance(4.8).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
-		for _, i := range h.Inventory(tx, pos).Clear() {
-			dropItem(tx, i, pos.Vec3())
-		}
+	return newBreakInfo(3, pickaxeHarvestable, pickaxeEffective, oneOf(Hopper{})).withBlastResistance(4.8).withAdditionalDrops(func(pos cube.Pos, tx *world.Tx, _ item.User) []item.Stack {
+		return h.Inventory(tx, pos).Items()
+	}).withBreakHandler(func(pos cube.Pos, tx *world.Tx, _ item.User) {
+		h.Inventory(tx, pos).Clear()
 	})
 }
 

--- a/server/block/item_frame.go
+++ b/server/block/item_frame.go
@@ -86,10 +86,11 @@ func (i ItemFrame) UseOnBlock(pos cube.Pos, face cube.Face, _ mgl64.Vec3, tx *wo
 
 // BreakInfo ...
 func (i ItemFrame) BreakInfo() BreakInfo {
-	return newBreakInfo(0.25, alwaysHarvestable, nothingEffective, oneOf(ItemFrame{Glowing: i.Glowing})).withBreakHandler(func(pos cube.Pos, tx *world.Tx, _ item.User) {
+	return newBreakInfo(0.25, alwaysHarvestable, nothingEffective, oneOf(ItemFrame{Glowing: i.Glowing})).withAdditionalDrops(func(cube.Pos, *world.Tx, item.User) []item.Stack {
 		if !i.Item.Empty() {
-			dropItem(tx, i.Item, pos.Vec3Centre())
+			return []item.Stack{i.Item}
 		}
+		return nil
 	})
 }
 

--- a/server/block/jukebox.go
+++ b/server/block/jukebox.go
@@ -55,9 +55,13 @@ func (j Jukebox) FuelInfo() item.FuelInfo {
 
 // BreakInfo ...
 func (j Jukebox) BreakInfo() BreakInfo {
-	return newBreakInfo(2, alwaysHarvestable, axeEffective, oneOf(Jukebox{})).withBlastResistance(6).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
+	return newBreakInfo(2, alwaysHarvestable, axeEffective, oneOf(Jukebox{})).withBlastResistance(6).withAdditionalDrops(func(cube.Pos, *world.Tx, item.User) []item.Stack {
 		if _, hasDisc := j.Disc(); hasDisc {
-			dropItem(tx, j.Item, pos.Vec3())
+			return []item.Stack{j.Item}
+		}
+		return nil
+	}).withBreakHandler(func(pos cube.Pos, tx *world.Tx, _ item.User) {
+		if _, hasDisc := j.Disc(); hasDisc {
 			tx.PlaySound(pos.Vec3Centre(), sound.MusicDiscEnd{})
 		}
 	})

--- a/server/block/shulker_box.go
+++ b/server/block/shulker_box.go
@@ -251,7 +251,17 @@ func shulkerPushDelta(facing cube.Face, shulkerBBox, entityBBox cube.BBox) (delt
 }
 
 func (s ShulkerBox) BreakInfo() BreakInfo {
-	return newBreakInfo(2, alwaysHarvestable, pickaxeEffective, oneOf(s))
+	return newBreakInfo(2, alwaysHarvestable, pickaxeEffective, simpleDrops()).withAdditionalDrops(func(_ cube.Pos, _ *world.Tx, u item.User) []item.Stack {
+		s = s.initialised()
+		if u != nil {
+			if g, ok := u.(interface{ GameMode() world.GameMode }); ok && g.GameMode().CreativeInventory() {
+				if s.inventory.Empty() {
+					return nil
+				}
+			}
+		}
+		return []item.Stack{item.NewStack(s, 1)}
+	})
 }
 
 func (s ShulkerBox) MaxCount() int {

--- a/server/block/smoker.go
+++ b/server/block/smoker.go
@@ -84,10 +84,10 @@ func (s Smoker) BreakInfo() BreakInfo {
 	if s.smelter != nil {
 		xp = s.Experience()
 	}
-	return newBreakInfo(3.5, alwaysHarvestable, pickaxeEffective, oneOf(Smoker{})).withXPDropRange(xp, xp).withBreakHandler(func(pos cube.Pos, tx *world.Tx, u item.User) {
-		for _, i := range s.Inventory(tx, pos).Clear() {
-			dropItem(tx, i, pos.Vec3())
-		}
+	return newBreakInfo(3.5, alwaysHarvestable, pickaxeEffective, oneOf(Smoker{})).withXPDropRange(xp, xp).withAdditionalDrops(func(pos cube.Pos, tx *world.Tx, _ item.User) []item.Stack {
+		return s.Inventory(tx, pos).Items()
+	}).withBreakHandler(func(pos cube.Pos, tx *world.Tx, _ item.User) {
+		s.Inventory(tx, pos).Clear()
 	})
 }
 

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2137,7 +2137,8 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 		return
 	}
 	held, _ := p.HeldItems()
-	drops := p.drops(held, b)
+	drops, additionalDropCount, additionalDropPosition := p.drops(pos, held, b)
+	originalDrops := slices.Clone(drops)
 
 	xp := 0
 	if breakable, ok := b.(block.Breakable); ok && !p.GameMode().CreativeInventory() {
@@ -2166,8 +2167,13 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 			p.tx.AddEntity(orb)
 		}
 	}
-	for _, drop := range drops {
-		opts := world.EntitySpawnOpts{Position: pos.Vec3Centre(), Velocity: mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1}}
+	preserveAdditionalPosition := additionalDropPosition != nil && additionalDropCount > 0 && len(drops) >= additionalDropCount && slices.EqualFunc(drops[len(drops)-additionalDropCount:], originalDrops[len(originalDrops)-additionalDropCount:], item.Stack.Equal)
+	for i, drop := range drops {
+		dropPos := pos.Vec3Centre()
+		if preserveAdditionalPosition && i >= len(drops)-additionalDropCount {
+			dropPos = additionalDropPosition(pos)
+		}
+		opts := world.EntitySpawnOpts{Position: dropPos, Velocity: mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1}}
 		p.tx.AddEntity(entity.NewItem(opts, drop))
 	}
 
@@ -2183,20 +2189,26 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 }
 
 // drops returns the drops that the player can get from the block passed using the item held.
-func (p *Player) drops(held item.Stack, b world.Block) []item.Stack {
+func (p *Player) drops(pos cube.Pos, held item.Stack, b world.Block) (drops []item.Stack, additionalDropCount int, additionalDropPosition func(cube.Pos) mgl64.Vec3) {
 	t, ok := held.Item().(item.Tool)
 	if !ok {
 		t = item.ToolNone{}
 	}
-	var drops []item.Stack
-	if breakable, ok := b.(block.Breakable); ok && !p.GameMode().CreativeInventory() {
-		if breakable.BreakInfo().Harvestable(t) {
-			drops = breakable.BreakInfo().Drops(t, held.Enchantments())
+	if breakable, ok := b.(block.Breakable); ok {
+		info := breakable.BreakInfo()
+		if !p.GameMode().CreativeInventory() && info.Harvestable(t) {
+			drops = append(drops, info.Drops(t, held.Enchantments())...)
+		}
+		if info.AdditionalDrops != nil {
+			additional := info.AdditionalDrops(pos, p.tx, p)
+			drops = append(drops, additional...)
+			additionalDropCount = len(additional)
+			additionalDropPosition = info.AdditionalDropPosition
 		}
 	} else if it, ok := b.(world.Item); ok && !p.GameMode().CreativeInventory() {
 		drops = []item.Stack{item.NewStack(it, 1)}
 	}
-	return drops
+	return drops, additionalDropCount, additionalDropPosition
 }
 
 // PickBlock makes the player pick a block in the world at a position passed. If the player is unable to

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2167,10 +2167,11 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 			p.tx.AddEntity(orb)
 		}
 	}
-	preserveAdditionalPosition := additionalDropPosition != nil && additionalDropCount > 0 && len(drops) >= additionalDropCount && slices.EqualFunc(drops[len(drops)-additionalDropCount:], originalDrops[len(originalDrops)-additionalDropCount:], item.Stack.Equal)
+	additionalDropStart, additionalDropEnd, preserveAdditionalPosition := unchangedAdditionalDropRange(drops, originalDrops, additionalDropCount)
+	preserveAdditionalPosition = preserveAdditionalPosition && additionalDropPosition != nil
 	for i, drop := range drops {
 		dropPos := pos.Vec3Centre()
-		if preserveAdditionalPosition && i >= len(drops)-additionalDropCount {
+		if preserveAdditionalPosition && i >= additionalDropStart && i < additionalDropEnd {
 			dropPos = additionalDropPosition(pos)
 		}
 		opts := world.EntitySpawnOpts{Position: dropPos, Velocity: mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1}}
@@ -2209,6 +2210,31 @@ func (p *Player) drops(pos cube.Pos, held item.Stack, b world.Block) (drops []it
 		drops = []item.Stack{item.NewStack(it, 1)}
 	}
 	return drops, additionalDropCount, additionalDropPosition
+}
+
+// unchangedAdditionalDropRange returns the current range of the original additional drops if a handler left them
+// together and unchanged.
+func unchangedAdditionalDropRange(drops, original []item.Stack, additionalCount int) (start, end int, ok bool) {
+	if additionalCount <= 0 || additionalCount > len(original) {
+		return 0, 0, false
+	}
+	if len(drops) >= len(original) && slices.EqualFunc(drops[:len(original)], original, item.Stack.Equal) {
+		return len(original) - additionalCount, len(original), true
+	}
+	additional := original[len(original)-additionalCount:]
+	match := -1
+	for candidate := 0; candidate+additionalCount <= len(drops); candidate++ {
+		if slices.EqualFunc(drops[candidate:candidate+additionalCount], additional, item.Stack.Equal) {
+			if match >= 0 {
+				return 0, 0, false
+			}
+			match = candidate
+		}
+	}
+	if match < 0 {
+		return 0, 0, false
+	}
+	return match, match + additionalCount, true
 }
 
 // PickBlock makes the player pick a block in the world at a position passed. If the player is unable to


### PR DESCRIPTION
## Summary
- move contained and special break drops into `block.BreakInfo.AdditionalDrops`
- expose the complete drop list to `HandleBlockBreak` before block/inventory mutation, with pure pre-event evaluation and cancellation safety
- migrate container, campfire, chest, composter, decorated pot, item frame, jukebox, and shulker behavior; preserve double-chest half inventory semantics
- apply the generalized drops to explosions while keeping ordinary drops chance-gated and shulker boxes intact

## Verification
- `go test ./...`
- `go vet ./...`
- `go test -race ./server/block ./server/player`
- `git diff --check`

No tests or test-file changes were added, per request.