### PR TITLE
server/item: export RepeatStacks over any countable stack

### DIFF
--- a/server/item/stack.go
+++ b/server/item/stack.go
@@ -3,6 +3,7 @@ package item
 import (
 	"fmt"
 	"maps"
+	"math"
 	"reflect"
 	"slices"
 	"sort"
@@ -490,4 +491,35 @@ func id(s Stack) int32 {
 // end, which is typically used for sending messages, popups and tips.
 func format(a []any) string {
 	return strings.TrimSuffix(fmt.Sprintln(a...), "\n")
+}
+
+// Repeatable is a stack RepeatStacks can split. Splitting needs to know how much a stack
+// holds and how much it may hold, and to build the pieces, which Grow does by returning the
+// same stack at a different count. Stack implements it, as does a type embedding one.
+type Repeatable[T any] interface {
+	// Count returns the number of items in the stack.
+	Count() int
+	// MaxCount returns the highest count a single stack of this item may hold.
+	MaxCount() int
+	// Grow returns the stack with its count changed by the amount passed.
+	Grow(int) T
+}
+
+// RepeatStacks multiplies the count of every stack passed by repetitions, splitting a
+// result that would exceed an item's max count across as many stacks as it takes.
+func RepeatStacks[T Repeatable[T]](items []T, repetitions int) []T {
+	output := make([]T, 0, len(items))
+	for _, o := range items {
+		count, maxCount := o.Count(), o.MaxCount()
+		total := count * repetitions
+
+		stacks := int(math.Ceil(float64(total) / float64(maxCount)))
+		for range stacks {
+			inc := min(total, maxCount)
+			total -= inc
+
+			output = append(output, o.Grow(inc-count))
+		}
+	}
+	return output
 }

--- a/server/session/handler_crafting.go
+++ b/server/session/handler_crafting.go
@@ -64,7 +64,7 @@ func (h *ItemStackRequestHandler) handleCraft(a *protocol.CraftRecipeStackReques
 			return fmt.Errorf("recipe %v: could not consume expected item: %v", a.RecipeNetworkID, expected)
 		}
 	}
-	return h.createResults(s, tx, repeatStacks(craft.Output(), timesCrafted)...)
+	return h.createResults(s, tx, item.RepeatStacks(craft.Output(), timesCrafted)...)
 }
 
 // handleAutoCraft handles the AutoCraftRecipe request action.
@@ -147,7 +147,7 @@ func (h *ItemStackRequestHandler) handleAutoCraft(a *protocol.AutoCraftRecipeSta
 		}
 	}
 
-	return h.createResults(s, tx, repeatStacks(craft.Output(), timesCrafted)...)
+	return h.createResults(s, tx, item.RepeatStacks(craft.Output(), timesCrafted)...)
 }
 
 // handleCreativeCraft handles the CreativeCraft request action.
@@ -209,25 +209,6 @@ func matchingStacks(has, expected recipe.Item) bool {
 		panic(fmt.Errorf("client has unexpected recipe item %T", has))
 	}
 	panic(fmt.Errorf("tried to match with unexpected recipe item %T", expected))
-}
-
-// repeatStacks multiplies the count of all item stacks provided by the number of repetitions provided. Item
-// stacks where the new count would exceed the item's max count are split into multiple item stacks.
-func repeatStacks(items []item.Stack, repetitions int) []item.Stack {
-	output := make([]item.Stack, 0, len(items))
-	for _, o := range items {
-		count, maxCount := o.Count(), o.MaxCount()
-		total := count * repetitions
-
-		stacks := int(math.Ceil(float64(total) / float64(maxCount)))
-		for i := 0; i < stacks; i++ {
-			inc := min(total, maxCount)
-			total -= inc
-
-			output = append(output, o.Grow(inc-count))
-		}
-	}
-	return output
 }
 
 func grow(i recipe.Item, count int) recipe.Item {
@@ -305,7 +286,7 @@ func (h *ItemStackRequestHandler) tryDynamicCraft(s *Session, tx *world.Tx, time
 			}
 		}
 
-		return h.createResults(s, tx, repeatStacks(output, timesCrafted)...)
+		return h.createResults(s, tx, item.RepeatStacks(output, timesCrafted)...)
 	}
 
 	return fmt.Errorf("no matching recipe found for crafting grid")

--- a/server/session/handler_stonecutter.go
+++ b/server/session/handler_stonecutter.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"fmt"
+	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/item/recipe"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
@@ -45,5 +46,5 @@ func (h *ItemStackRequestHandler) handleStonecutting(a *protocol.CraftRecipeStac
 		Container: protocol.FullContainerName{ContainerID: protocol.ContainerStonecutterInput},
 		Slot:      stonecutterInputSlot,
 	}, input.Grow(-timesCrafted), s, tx)
-	return h.createResults(s, tx, repeatStacks(output, timesCrafted)...)
+	return h.createResults(s, tx, item.RepeatStacks(output, timesCrafted)...)
 }


### PR DESCRIPTION
`repeatStacks` splits a repeated crafting output across as many stacks as the item's max count needs. Nothing about that is specific to `item.Stack` — it needs a count, a max count, and a way to grow.

Being unexported and typed to `[]item.Stack`, a consumer holding its own stack type has to retype the arithmetic. In our Bedrock proxy the inventory overlay has exactly this function, line for line, over a type that embeds `item.Stack` alongside a network ID and NBT.

Converting instead of copying does not work: the split means outputs do not correspond 1:1 to inputs, so there is nothing to map the extra state back onto after the call.

```go
type Repeatable[T any] interface {
	Count() int
	MaxCount() int
	Grow(int) T
}

func RepeatStacks[T Repeatable[T]](items []T, repetitions int) []T
```

`item.Stack` satisfies it unchanged. It lives in `stack.go` next to the three methods it is built on. `handler_crafting` and `handler_stonecutter` call the exported form, so behaviour is unchanged.

## Validation
`go build ./...`, `go test ./server/... -count=1`. Happy to add tests here if you would like them — left out to keep the diff to the change itself.