### PR TITLE
server/world: Add fall damage world setting

### DIFF
--- a/server/entity/ender_pearl.go
+++ b/server/entity/ender_pearl.go
@@ -42,7 +42,9 @@ func teleport(e *Ent, tx *world.Tx, target trace.Result) {
 	if user, ok := owner.(teleporter); ok {
 		tx.PlaySound(user.Position(), sound.Teleport{})
 		user.Teleport(target.Position())
-		user.Hurt(5, FallDamageSource{})
+		if tx.World().FallDamage() {
+			user.Hurt(5, FallDamageSource{})
+		}
 	}
 }
 

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -582,6 +582,9 @@ func (p *Player) fall(distance float64) {
 	if h, ok := b.(block.EntityLander); ok {
 		h.EntityLand(pos, p.tx, p, &distance)
 	}
+	if !p.tx.World().FallDamage() {
+		return
+	}
 	dmg := distance - 3
 	if boost, ok := p.Effect(effect.JumpBoost); ok {
 		dmg -= float64(boost.Level())

--- a/server/world/mcdb/leveldat/data.go
+++ b/server/world/mcdb/leveldat/data.go
@@ -247,6 +247,7 @@ func (d *Data) Settings() *world.Settings {
 		DefaultGameMode: mode,
 		Difficulty:      difficulty,
 		TickRange:       d.ServerChunkTickRange,
+		FallDamage:      d.FallDamage,
 	}
 }
 
@@ -268,6 +269,7 @@ func (d *Data) PutSettings(s *world.Settings) {
 	}
 	d.CurrentTick = s.CurrentTick
 	d.ServerChunkTickRange = s.TickRange
+	d.FallDamage = s.FallDamage
 	mode, _ := world.GameModeID(s.DefaultGameMode)
 	d.GameType = int32(mode)
 	difficulty, _ := world.DifficultyID(s.Difficulty)

--- a/server/world/settings.go
+++ b/server/world/settings.go
@@ -44,6 +44,9 @@ type Settings struct {
 	// TickRange is the radius in chunks around a Viewer that has its blocks and entities ticked when the world is
 	// ticked. If set to 0, blocks and entities will never be ticked.
 	TickRange int32
+	// FallDamage specifies if entities take damage from falling in this World. If set to false, falls are
+	// harmless. It matches the falldamage game rule.
+	FallDamage bool
 }
 
 // defaultSettings returns the default Settings for a new World.
@@ -55,5 +58,6 @@ func defaultSettings() *Settings {
 		TimeCycle:       true,
 		WeatherCycle:    true,
 		TickRange:       6,
+		FallDamage:      true,
 	}
 }

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -1094,6 +1094,26 @@ func (w *World) SetDifficulty(d Difficulty) {
 	w.set.Difficulty = d
 }
 
+// FallDamage checks if entities in the World take damage from falling.
+func (w *World) FallDamage() bool {
+	if w == nil {
+		return false
+	}
+	w.set.Lock()
+	defer w.set.Unlock()
+	return w.set.FallDamage
+}
+
+// SetFallDamage toggles whether entities in the World take damage from falling.
+func (w *World) SetFallDamage(v bool) {
+	if w == nil {
+		return
+	}
+	w.set.Lock()
+	defer w.set.Unlock()
+	w.set.FallDamage = v
+}
+
 // scheduleBlockUpdate schedules a block update at the position passed for the
 // block type passed after a specific delay. If the block at that position does
 // not handle block updates, nothing will happen.


### PR DESCRIPTION
Adds Settings.FallDamage, mapped to the falldamage game rule already parsed from level.dat but previously unused. Player fall damage and ender pearl damage now respect it. Defaults to true.