### PR TITLE
server: Allow setting rotation when teleporting

### DIFF
--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -69,8 +69,14 @@ func (e *Ent) SetVelocity(v mgl64.Vec3) {
 
 // Teleport teleports the entity to the position given.
 func (e *Ent) Teleport(pos mgl64.Vec3) {
+	e.TeleportRotated(pos, e.Rotation())
+}
+
+// TeleportRotated teleports the entity to the position given, facing the rotation passed.
+func (e *Ent) TeleportRotated(pos mgl64.Vec3, rot cube.Rotation) {
 	viewers := e.tx.Viewers(e.data.Pos)
 	e.data.Pos = pos
+	e.data.Rot = rot
 	for _, v := range viewers {
 		v.ViewEntityTeleport(e, pos)
 	}

--- a/server/player/handler.go
+++ b/server/player/handler.go
@@ -22,7 +22,8 @@ type Handler interface {
 	// HandleJump handles the player jumping.
 	HandleJump(p *Player)
 	// HandleTeleport handles the teleportation of a player. ctx.Cancel() may be called to cancel it.
-	HandleTeleport(ctx *Context, pos mgl64.Vec3)
+	// The destination position and rotation are passed.
+	HandleTeleport(ctx *Context, pos mgl64.Vec3, rot cube.Rotation)
 	// HandleChangeWorld handles when the player is added to a new world. before may be nil.
 	HandleChangeWorld(p *Player, before, after *world.World)
 	// HandleToggleSprint handles when the player starts or stops sprinting.
@@ -168,7 +169,7 @@ func (NopHandler) HandleItemDrop(*Context, item.Stack)                          
 func (NopHandler) HandleHeldSlotChange(*Context, int, int)                                 {}
 func (NopHandler) HandleMove(*Context, mgl64.Vec3, cube.Rotation)                          {}
 func (NopHandler) HandleJump(*Player)                                                      {}
-func (NopHandler) HandleTeleport(*Context, mgl64.Vec3)                                     {}
+func (NopHandler) HandleTeleport(*Context, mgl64.Vec3, cube.Rotation)                      {}
 func (NopHandler) HandleChangeWorld(*Player, *world.World, *world.World)                   {}
 func (NopHandler) HandleToggleSprint(*Context, bool)                                       {}
 func (NopHandler) HandleToggleSneak(*Context, bool)                                        {}

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2256,10 +2256,17 @@ func (p *Player) PickBlock(pos cube.Pos) {
 // Teleport teleports the player to a target position in the world. Unlike Move, it immediately changes the
 // position of the player, rather than showing an animation.
 func (p *Player) Teleport(pos mgl64.Vec3) {
+	p.TeleportRotated(pos, p.Rotation())
+}
+
+// TeleportRotated teleports the player to a target position in the world, facing the rotation passed. Unlike
+// Move, it immediately changes the position and rotation of the player, rather than showing an animation.
+func (p *Player) TeleportRotated(pos mgl64.Vec3, rot cube.Rotation) {
 	ctx := newContext(p)
 	if p.Handler().HandleTeleport(ctx, pos); ctx.Cancelled() {
 		return
 	}
+	p.data.Rot = rot
 	p.forceTeleport(pos)
 }
 

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -2263,7 +2263,7 @@ func (p *Player) Teleport(pos mgl64.Vec3) {
 // Move, it immediately changes the position and rotation of the player, rather than showing an animation.
 func (p *Player) TeleportRotated(pos mgl64.Vec3, rot cube.Rotation) {
 	ctx := newContext(p)
-	if p.Handler().HandleTeleport(ctx, pos); ctx.Cancelled() {
+	if p.Handler().HandleTeleport(ctx, pos, rot); ctx.Cancelled() {
 		return
 	}
 	p.data.Rot = rot


### PR DESCRIPTION
Teleport only moved an entity, with no way to set the direction it faces on arrival. Adds an optional rotation to Player.Teleport and Ent.Teleport, applied before viewers are notified so it rides along in the existing movement packet.