### PR TITLE
Remove repanic

### DIFF
--- a/server/player/ref.go
+++ b/server/player/ref.go
@@ -25,8 +25,7 @@ func DoAfter(h *world.EntityHandle, delay time.Duration, f func(tx *world.Tx, p 
 }
 
 // Call runs f with the player identified by h on its current world owner and
-// waits for its typed result. If f panics, Call re-panics with the original
-// value on the waiting goroutine.
+// waits for its typed result.
 func Call[T any](ctx context.Context, h *world.EntityHandle, f func(tx *world.Tx, p *Player) (T, error)) (T, error) {
 	return world.CallRef(ctx, NewRef(h), f)
 }

--- a/server/world/entity_ref.go
+++ b/server/world/entity_ref.go
@@ -43,8 +43,7 @@ func typed[T Entity](f func(tx *Tx, e T)) func(*Tx, Entity) error {
 }
 
 // CallRef runs f with the ref's entity on its current world owner and waits
-// for the typed result. Off-owner code only, like Call. If f panics, CallRef
-// re-panics with the original value on the waiting goroutine. Context
+// for the typed result. Off-owner code only, like Call. Context
 // cancellation stops pending work, but CallRef waits for a callback that has
 // already started.
 func CallRef[T any, E Entity](ctx context.Context, ref EntityRef[E], f func(tx *Tx, e E) (T, error)) (T, error) {

--- a/server/world/task.go
+++ b/server/world/task.go
@@ -28,7 +28,7 @@ var (
 
 // PanicError is the Task error for a fire-and-forget callback that panicked. It
 // matches errors.Is(err, ErrTaskPanicked) and keeps the original panic value
-// and stack. Synchronous Call functions re-panic with Value automatically.
+// and stack.
 type PanicError struct {
 	// Value is the recovered panic value.
 	Value any
@@ -306,9 +306,7 @@ func (w *World) DoAfter(delay time.Duration, f func(tx *Tx)) *Task {
 // Call runs f on w's owner and waits for its typed result. It is for
 // off-owner code such as tests, startup and background goroutines; if you
 // already have a *world.Tx, just use it directly. Calling it from the
-// owner itself (any scheduled callback or Handler event) deadlocks. If f
-// panics, Call re-panics with the original value on the waiting goroutine after
-// logging the original stack through the World's Logger. Context cancellation
+// owner itself (any scheduled callback or Handler event) deadlocks. Context cancellation
 // stops pending work, but Call waits for a callback that has already started.
 func Call[T any](ctx context.Context, w *World, f func(tx *Tx) (T, error)) (T, error) {
 	var zero T
@@ -327,7 +325,6 @@ func Call[T any](ctx context.Context, w *World, f func(tx *Tx) (T, error)) (T, e
 
 // CallEntity runs f with the EntityHandle's entity on its current world owner
 // and waits for the typed result. Off-owner code only, like Call. If f panics,
-// CallEntity re-panics with the original value on the waiting goroutine.
 func CallEntity[T any](ctx context.Context, h *EntityHandle, f func(tx *Tx, e Entity) (T, error)) (T, error) {
 	return CallRef(ctx, NewEntityRef[Entity](h), f)
 }

--- a/server/world/task.go
+++ b/server/world/task.go
@@ -44,14 +44,6 @@ func (e *PanicError) Error() string {
 // Unwrap returns ErrTaskPanicked so errors.Is works.
 func (e *PanicError) Unwrap() error { return ErrTaskPanicked }
 
-// rethrowPanic re-panics with the original panic value if err wraps a
-// *PanicError. It does nothing for any other error, including nil.
-func rethrowPanic(err error) {
-	if pe, ok := errors.AsType[*PanicError](err); ok {
-		panic(pe.Value)
-	}
-}
-
 // callContext normalises a possibly-nil caller context and reports whether it
 // was cancelled before any work was scheduled.
 func callContext(ctx context.Context) (context.Context, error) {
@@ -81,7 +73,6 @@ func awaitTask[T any](ctx context.Context, task *Task, result *T) (T, error) {
 	var zero T
 	completed := func() (T, error) {
 		if err := task.Err(); err != nil {
-			rethrowPanic(err)
 			return zero, err
 		}
 		return *result, nil


### PR DESCRIPTION
do anyone really likes this behavior? repanic happens on the critical path where server handles player's packets and instead of kicking the player who caused the panic, repanic just crashes the entire server