### PR TITLE
server/session: fix closing a session without a transaction panicking

### DIFF
--- a/server/session/session.go
+++ b/server/session/session.go
@@ -332,8 +332,7 @@ func (s *Session) close(tx *world.Tx, c Controllable) {
 	// early.
 	if tx != nil {
 		tx.RemoveEntity(c)
-		// The handle is only closed once the entity has been removed from its world: closing one that is still in a
-		// world panics. Without a transaction the entity cannot be removed, so its handle is left alone.
+		// Closing a handle that is still in a world panics.
 		_ = s.ent.Close()
 	}
 

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -332,8 +332,10 @@ func (s *Session) close(tx *world.Tx, c Controllable) {
 	// early.
 	if tx != nil {
 		tx.RemoveEntity(c)
+		// The handle is only closed once the entity has been removed from its world: closing one that is still in a
+		// world panics. Without a transaction the entity cannot be removed, so its handle is left alone.
+		_ = s.ent.Close()
 	}
-	_ = s.ent.Close()
 
 	// This should always be called last due to the timing of the removal of
 	// entity runtime IDs.

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -332,7 +332,6 @@ func (s *Session) close(tx *world.Tx, c Controllable) {
 	// early.
 	if tx != nil {
 		tx.RemoveEntity(c)
-		// Closing a handle that is still in a world panics.
 		_ = s.ent.Close()
 	}
 


### PR DESCRIPTION
### What happens and why

Closing a session without a transaction skips removing the controllable from
its world, as there is no transaction to remove it with, but still closed the
handle of that entity. Closing a handle that is still in a world panics, so a
session closed this way takes the goroutine that closed it down with it.

The handle is only closed when the entity was removed. Leaving it open is what
the rest of that branch already does with the chunk loader and the container.

### Verification

Reproduced in process against a real session: `Session.Close(nil, c)` panics with `cannot add entity to new world before removing from old world` when the controllable is still in a world.
