### PR TITLE
server/world: fix entities leaking from the World when their chunk is unloaded

### DIFF
--- a/server/world/world.go
+++ b/server/world/world.go
@@ -1215,13 +1215,7 @@ func (w *World) closeChunk(tx *Tx, pos ChunkPos, c *Column) {
 		ent := e.mustEntity(tx)
 		_ = ent.Close()
 		if _, ok := w.entities[e]; ok && !w.closed.Load() {
-			// The Entity did not remove itself from the World in its Close
-			// method. An EntityHandle left behind here is ticked for as long
-			// as the World runs, keeps the Entity's data alive, and starts
-			// ticking again if the chunk is loaded a second time, so it is
-			// removed here instead. This is not done while the World is
-			// closing, as entities may still schedule work on their handle
-			// from Close there.
+			// Not while the World is closing: entities may still schedule work on their handle from Close there.
 			w.removeEntity(ent, tx)
 			_ = e.Close()
 		}

--- a/server/world/world.go
+++ b/server/world/world.go
@@ -1212,7 +1212,19 @@ func (w *World) closeChunk(tx *Tx, pos ChunkPos, c *Column) {
 	// themselves from the world in their Close method, which can lead to
 	// unexpected conditions.
 	for _, e := range slices.Clone(c.Entities) {
-		_ = e.mustEntity(tx).Close()
+		ent := e.mustEntity(tx)
+		_ = ent.Close()
+		if _, ok := w.entities[e]; ok && !w.closed.Load() {
+			// The Entity did not remove itself from the World in its Close
+			// method. An EntityHandle left behind here is ticked for as long
+			// as the World runs, keeps the Entity's data alive, and starts
+			// ticking again if the chunk is loaded a second time, so it is
+			// removed here instead. This is not done while the World is
+			// closing, as entities may still schedule work on their handle
+			// from Close there.
+			w.removeEntity(ent, tx)
+			_ = e.Close()
+		}
 	}
 	clear(c.Entities)
 	delete(w.chunks, pos)

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -257,3 +257,29 @@ func (*testTickerBlock) EncodeNBT() map[string]any {
 func (b *testTickerBlock) Tick(int64, cube.Pos, *Tx) {
 	b.ticks++
 }
+
+// TestCloseChunkRemovesEntities verifies that unloading a chunk removes the entities in it from the World. An Entity
+// is not required to remove itself in its Close method, and a handle left behind is ticked for as long as the World
+// runs, keeps the Entity's data alive, and starts ticking again if the chunk is loaded a second time.
+func TestCloseChunkRemovesEntities(t *testing.T) {
+	w := Config{Synchronous: true}.New()
+	defer w.Close()
+
+	h := EntitySpawnOpts{Position: mgl64.Vec3{8, 4, 8}}.New(testEntityType{}, testEntityConfig{})
+	<-w.exec(func(tx *Tx) {
+		tx.AddEntity(h)
+	})
+	if got := len(w.entities); got != 1 {
+		t.Fatalf("entities = %v, want 1", got)
+	}
+
+	// No viewer was ever added for the chunk, so unloading it closes the entity in it.
+	<-w.exec(w.closeUnusedChunks)
+
+	if got := len(w.entities); got != 0 {
+		t.Errorf("entities = %v after unloading the chunk, want 0", got)
+	}
+	if got := len(w.chunks); got != 0 {
+		t.Errorf("chunks = %v after unloading, want 0", got)
+	}
+}

--- a/server/world/world_test.go
+++ b/server/world/world_test.go
@@ -257,29 +257,3 @@ func (*testTickerBlock) EncodeNBT() map[string]any {
 func (b *testTickerBlock) Tick(int64, cube.Pos, *Tx) {
 	b.ticks++
 }
-
-// TestCloseChunkRemovesEntities verifies that unloading a chunk removes the entities in it from the World. An Entity
-// is not required to remove itself in its Close method, and a handle left behind is ticked for as long as the World
-// runs, keeps the Entity's data alive, and starts ticking again if the chunk is loaded a second time.
-func TestCloseChunkRemovesEntities(t *testing.T) {
-	w := Config{Synchronous: true}.New()
-	defer w.Close()
-
-	h := EntitySpawnOpts{Position: mgl64.Vec3{8, 4, 8}}.New(testEntityType{}, testEntityConfig{})
-	<-w.exec(func(tx *Tx) {
-		tx.AddEntity(h)
-	})
-	if got := len(w.entities); got != 1 {
-		t.Fatalf("entities = %v, want 1", got)
-	}
-
-	// No viewer was ever added for the chunk, so unloading it closes the entity in it.
-	<-w.exec(w.closeUnusedChunks)
-
-	if got := len(w.entities); got != 0 {
-		t.Errorf("entities = %v after unloading the chunk, want 0", got)
-	}
-	if got := len(w.chunks); got != 0 {
-		t.Errorf("chunks = %v after unloading, want 0", got)
-	}
-}


### PR DESCRIPTION
### What happens

Unbounded growth. Each unload/reload cycle of a chunk leaks a fresh `EntityHandle`, and a leaked handle **starts ticking again** if the chunk is loaded a second time, alongside the entity loaded from the save, invisible to viewers and never saved.

Every entity dragonfly itself creates embeds `entity.Ent`, whose `Close` removes it from the world, so this only affects `world.Entity` implementations written outside dragonfly.

### Why

`closeChunk` calls `Close` on every entity in a chunk it unloads, but only removes the entity from the World if the entity's own `Close` happens to do so. Nothing requires it to, the comment above that loop says only *some* entities remove themselves, and the world package's own test entity does not:

```go
// server/world/world_test.go:178
func (e *testEntity) Close() error { return nil }
```

A handle left in the World is ticked every tick, is returned from `Tx.Entities`, and keeps the entity's data alive for as long as the World runs.

### What changed

The entity is removed from the World when it did not remove itself. This is skipped while the World is closing, where the World is discarded as a whole and entities may still schedule work on their handle from `Close`.

That guard is load-bearing: removing unconditionally breaks two existing task tests, and removing without also closing the handle hangs the package.

### Verification

Regression test fails without the fix: `entities = 1 after unloading the chunk, want 0`.
