### PR TITLE
server/entity: fix a firework damaging players through walls

### DIFF
--- a/server/entity/firework_behaviour.go
+++ b/server/entity/firework_behaviour.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/cube/trace"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
@@ -131,10 +132,12 @@ func (f *FireworkBehaviour) explode(e *Ent, tx *world.Tx) {
 			victim.(Living).Hurt(dmg, src)
 			continue
 		}
-		res, ok := trace.Perform(pos, tpos, tx, victim.H().Type().BBox(victim).Grow(0.3), nil)
-		if _, blocked := res.(trace.BlockResult); ok && !blocked {
-			// A block between the firework and the victim stops the damage: Perform reports a hit for the block it
-			// stopped at as well as for an entity, so the hit has to be the entity to count.
+		var obstructed bool
+		trace.TraverseBlocks(pos, tpos, func(bpos cube.Pos) bool {
+			_, obstructed = trace.BlockIntercept(bpos, tx, tx.Block(bpos), pos, tpos)
+			return !obstructed
+		})
+		if !obstructed {
 			victim.(Living).Hurt(dmg, src)
 		}
 	}

--- a/server/entity/firework_behaviour.go
+++ b/server/entity/firework_behaviour.go
@@ -131,7 +131,10 @@ func (f *FireworkBehaviour) explode(e *Ent, tx *world.Tx) {
 			victim.(Living).Hurt(dmg, src)
 			continue
 		}
-		if _, ok := trace.Perform(pos, tpos, tx, victim.H().Type().BBox(victim).Grow(0.3), nil); ok {
+		res, ok := trace.Perform(pos, tpos, tx, victim.H().Type().BBox(victim).Grow(0.3), nil)
+		if _, blocked := res.(trace.BlockResult); ok && !blocked {
+			// A block between the firework and the victim stops the damage: Perform reports a hit for the block it
+			// stopped at as well as for an entity, so the hit has to be the entity to count.
 			victim.(Living).Hurt(dmg, src)
 		}
 	}


### PR DESCRIPTION
### What happens and why

The check for a clear line between an exploding firework and a victim treats
any hit as a clear line. trace.Perform reports a hit for the block it stopped
at as well as for an entity, so a wall between the two satisfied it and the
damage was dealt through the wall. Only a hit that is not a block counts now.

### Verification

Reproduced in process: a firework exploding on the far side of a wall damages a player through it. `trace.Perform` reports a hit for the block it stopped at (`server/block/cube/trace/result.go:32`) as well as for an entity, so the guard that was meant to require a clear line accepted the wall as one.

No unit test: the fix is a type check on a result the surrounding code already has, and reaching it needs a firework entity, a victim and a wall in a live world.
