### PR TITLE
server/entity: fix an entity being ticked on after its behaviour closed it

### DIFF
--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -158,8 +158,6 @@ func (e *Ent) Tick(tx *world.Tx, current int64) {
 
 	m := e.Behaviour().Tick(e, tx)
 	if e.handle.Closed() {
-		// The behaviour closed the entity, so the rest of the tick would run on an entity that is no longer in the
-		// world and would age it past the point it stopped existing.
 		return
 	}
 	if e.finishPendingPortalTravel(tx) {

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -157,6 +157,11 @@ func (e *Ent) Tick(tx *world.Tx, current int64) {
 	e.SetOnFire(e.OnFireDuration() - time.Second/20)
 
 	m := e.Behaviour().Tick(e, tx)
+	if e.handle.Closed() {
+		// The behaviour closed the entity, so the rest of the tick would run on an entity that is no longer in the
+		// world and would age it past the point it stopped existing.
+		return
+	}
 	if e.finishPendingPortalTravel(tx) {
 		return
 	}


### PR DESCRIPTION
### What happens and why

The behaviour of an entity may close it, which removes it from the world, but
the rest of the tick ran regardless: portal contact was tracked and the age of
the entity was still advanced, on an entity that no longer exists. The tick
stops as soon as the behaviour has closed it.

### How this is known

Driven in process against a real `entity.Ent` built by `entity.Open`, with a real `PassiveBehaviour` whose `Tick` closes the entity:

```
before Tick: handle.Closed() = false, Age = 0s
after  Tick: handle.Closed() = true, Age = 50ms
the behaviour called Ent.Close() during Tick; Ent.Tick then continued past Behaviour().Tick
```

Closing an entity from inside its own tick is what the stock behaviours do, not something contrived for the reproduction: `ItemBehaviour` calls `e.Close()` from six places in its tick path, including when two item entities merge, where it closes both the entity and the one it merged with (`server/entity/item_behaviour.go:166-167`).

### What is not shown

There is no test on this branch. The age advancing on a closed entity is demonstrated by the program above but is not pinned by an assertion in the suite, so nothing prevents it regressing. The interaction I reasoned about rather than demonstrated is portal travel: travel is only queued while the behaviour runs and is completed afterwards, so the guard should not be able to fire on an entity that is mid-transfer, but I did not build the case that would prove it.
