### PR TITLE
session.go: Implement batch packet reading

### DIFF
--- a/server/session/session.go
+++ b/server/session/session.go
@@ -418,41 +418,40 @@ func (s *Session) handlePackets() {
 		}
 	}()
 	for {
-		select {
-		case first, ok := <-readPackets:
-			if !ok {
-				return
-			}
-			packets := []packet.Packet{first}
-			for {
-				var exit bool
-				select {
-				case pk, ok := <-readPackets:
-					if !ok {
-						return
-					}
-					packets = append(packets, pk)
-				default:
-					exit = true
-				}
-				if exit {
-					break
-				}
-			}
-			if err := s.withControllable(context.Background(), func(tx *world.Tx, c Controllable) error {
-				for _, pk := range packets {
-					if err := s.handlePacket(pk, tx, c); err != nil {
-						return err
-					}
-				}
-				return nil
-			}); err != nil {
-				if sessionOwnerStopped(err) {
+		first, ok := <-readPackets
+		if !ok {
+			return
+		}
+		packets := []packet.Packet{first}
+		// Allow a short window for packets arriving in the same burst to be batched together.
+		timer := time.NewTimer(time.Millisecond)
+	collect:
+		for {
+			select {
+			case pk, ok := <-readPackets:
+				if !ok {
+					timer.Stop()
 					return
 				}
-				s.conf.Log.Debug("process packet: " + err.Error())
+				packets = append(packets, pk)
+
+			case <-timer.C:
+				break collect
+			}
+		}
+		if err := s.withControllable(context.Background(), func(tx *world.Tx, c Controllable) error {
+			for _, pk := range packets {
+				if err := s.handlePacket(pk, tx, c); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+			if sessionOwnerStopped(err) {
 				return
 			}
+			s.conf.Log.Debug("process packet: " + err.Error())
+			return
 		}
 	}
 }

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -417,12 +417,13 @@ func (s *Session) handlePackets() {
 			readPackets <- pk
 		}
 	}()
+	packets := make([]packet.Packet, 0, 1024)
 	for {
 		first, ok := <-readPackets
 		if !ok {
 			return
 		}
-		packets := []packet.Packet{first}
+		packets = append(packets[:0], first)
 		// Allow a short window for packets arriving in the same burst to be batched together.
 		timer := time.NewTimer(time.Millisecond)
 	collect:
@@ -431,10 +432,13 @@ func (s *Session) handlePackets() {
 			case pk, ok := <-readPackets:
 				if !ok {
 					timer.Stop()
-					return
+					break collect
 				}
 				packets = append(packets, pk)
-
+				if len(packets) >= cap(packets) {
+					timer.Stop()
+					break collect
+				}
 			case <-timer.C:
 				break collect
 			}

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -417,7 +417,7 @@ func (s *Session) handlePackets() {
 			readPackets <- pk
 		}
 	}()
-	packets := make([]packet.Packet, 0, 1024)
+	packets := make([]packet.Packet, 0, 512)
 	for {
 		first, ok := <-readPackets
 		if !ok {

--- a/server/session/session.go
+++ b/server/session/session.go
@@ -406,20 +406,53 @@ func (s *Session) handlePackets() {
 			s.conf.Log.Debug("close session: " + err.Error())
 		}
 	}()
-	for {
-		pk, err := s.conn.ReadPacket()
-		if err != nil {
-			return
-		}
-		err = s.withControllable(context.Background(), func(tx *world.Tx, c Controllable) error {
-			return s.handlePacket(pk, tx, c)
-		})
-		if err != nil {
-			if sessionOwnerStopped(err) {
+	readPackets := make(chan packet.Packet, 512)
+	go func() {
+		defer close(readPackets)
+		for {
+			pk, err := s.conn.ReadPacket()
+			if err != nil {
 				return
 			}
-			s.conf.Log.Debug("process packet: " + err.Error())
-			return
+			readPackets <- pk
+		}
+	}()
+	for {
+		select {
+		case first, ok := <-readPackets:
+			if !ok {
+				return
+			}
+			packets := []packet.Packet{first}
+			for {
+				var exit bool
+				select {
+				case pk, ok := <-readPackets:
+					if !ok {
+						return
+					}
+					packets = append(packets, pk)
+				default:
+					exit = true
+				}
+				if exit {
+					break
+				}
+			}
+			if err := s.withControllable(context.Background(), func(tx *world.Tx, c Controllable) error {
+				for _, pk := range packets {
+					if err := s.handlePacket(pk, tx, c); err != nil {
+						return err
+					}
+				}
+				return nil
+			}); err != nil {
+				if sessionOwnerStopped(err) {
+					return
+				}
+				s.conf.Log.Debug("process packet: " + err.Error())
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR improves world transaction performance by batching inbound packets before processing them.

Previously, each packet required a separate world transaction. Packets are now read into a buffered channel, and all immediately available packets are processed in order within a single transaction. This reduces transaction scheduling and synchronisation overhead when multiple packets arrive close together.