### PR TITLE
block/item: Give swords and shears per-block mining speeds

### DIFF
--- a/server/block/bamboo.go
+++ b/server/block/bamboo.go
@@ -53,8 +53,11 @@ func (b Bamboo) FlammabilityInfo() FlammabilityInfo {
 
 // BreakInfo ...
 func (b Bamboo) BreakInfo() BreakInfo {
-	return newBreakInfo(1, alwaysHarvestable, axeEffective, oneOf(b))
+	return newBreakInfo(1, alwaysHarvestable, anyEffective(item.TypeAxe, item.TypeSword), oneOf(b))
 }
+
+// SwordMiningSpeed is high enough for a sword to break bamboo in one tick.
+func (Bamboo) SwordMiningSpeed() float64 { return 30 }
 
 // EncodeBlock ...
 func (b Bamboo) EncodeBlock() (string, map[string]any) {

--- a/server/block/bamboo_sapling.go
+++ b/server/block/bamboo_sapling.go
@@ -53,8 +53,11 @@ func (b BambooSapling) RandomTick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 
 // BreakInfo ...
 func (b BambooSapling) BreakInfo() BreakInfo {
-	return newBreakInfo(0, alwaysHarvestable, axeEffective, oneOf(Bamboo{})).withBlastResistance(1)
+	return newBreakInfo(0, alwaysHarvestable, anyEffective(item.TypeAxe, item.TypeSword), oneOf(Bamboo{})).withBlastResistance(1)
 }
+
+// SwordMiningSpeed ...
+func (BambooSapling) SwordMiningSpeed() float64 { return 30 }
 
 // HasLiquidDrops ...
 func (b BambooSapling) HasLiquidDrops() bool {

--- a/server/block/break_info.go
+++ b/server/block/break_info.go
@@ -215,6 +215,14 @@ var nothingEffective = func(item.Tool) bool {
 	return false
 }
 
+// anyEffective is a convenience function for blocks that are effectively mined with more than one type
+// of tool.
+func anyEffective(types ...item.ToolType) func(item.Tool) bool {
+	return func(t item.Tool) bool {
+		return slices.Contains(types, t.ToolType())
+	}
+}
+
 // alwaysHarvestable is a convenience function for blocks that are harvestable using any item.
 var alwaysHarvestable = func(t item.Tool) bool {
 	return true

--- a/server/block/cobweb.go
+++ b/server/block/cobweb.go
@@ -16,6 +16,12 @@ type Cobweb struct {
 // Cobweb is implemented because the item package needs to identify this block but cannot implement the block package.
 func (Cobweb) Cobweb() {}
 
+// SwordMiningSpeed ...
+func (Cobweb) SwordMiningSpeed() float64 { return 15 }
+
+// ShearsMiningSpeed ...
+func (Cobweb) ShearsMiningSpeed() float64 { return 15 }
+
 // EntityInside slows the entity's velocity and resets its fall distance while it is inside the cobweb.
 func (Cobweb) EntityInside(_ cube.Pos, _ *world.Tx, e world.Entity) {
 	if fallEntity, ok := e.(fallDistanceEntity); ok {

--- a/server/block/cocoa_bean.go
+++ b/server/block/cocoa_bean.go
@@ -88,13 +88,16 @@ func (c CocoaBean) RandomTick(pos cube.Pos, tx *world.Tx, r *rand.Rand) {
 
 // BreakInfo ...
 func (c CocoaBean) BreakInfo() BreakInfo {
-	return newBreakInfo(0.2, alwaysHarvestable, axeEffective, func(item.Tool, []item.Enchantment) []item.Stack {
+	return newBreakInfo(0.2, alwaysHarvestable, anyEffective(item.TypeAxe, item.TypeSword), func(item.Tool, []item.Enchantment) []item.Stack {
 		if c.Age == 2 {
 			return []item.Stack{item.NewStack(c, rand.IntN(2)+2)}
 		}
 		return []item.Stack{item.NewStack(c, 1)}
 	}).withBlastResistance(3)
 }
+
+// SwordMiningSpeed ...
+func (CocoaBean) SwordMiningSpeed() float64 { return 1.5 }
 
 // CompostChance ...
 func (CocoaBean) CompostChance() float64 {

--- a/server/block/leaves.go
+++ b/server/block/leaves.go
@@ -89,6 +89,12 @@ func (l Leaves) NeighbourUpdateTick(pos, _ cube.Pos, tx *world.Tx) {
 	}
 }
 
+// SwordMiningSpeed ...
+func (Leaves) SwordMiningSpeed() float64 { return 1.5 }
+
+// ShearsMiningSpeed ...
+func (Leaves) ShearsMiningSpeed() float64 { return 15 }
+
 // FlammabilityInfo ...
 func (l Leaves) FlammabilityInfo() FlammabilityInfo {
 	return newFlammabilityInfo(30, 60, true)
@@ -96,9 +102,7 @@ func (l Leaves) FlammabilityInfo() FlammabilityInfo {
 
 // BreakInfo ...
 func (l Leaves) BreakInfo() BreakInfo {
-	return newBreakInfo(0.2, alwaysHarvestable, func(t item.Tool) bool {
-		return t.ToolType() == item.TypeShears || t.ToolType() == item.TypeHoe
-	}, func(t item.Tool, enchantments []item.Enchantment) []item.Stack {
+	return newBreakInfo(0.2, alwaysHarvestable, anyEffective(item.TypeShears, item.TypeHoe, item.TypeSword), func(t item.Tool, enchantments []item.Enchantment) []item.Stack {
 		if t.ToolType() == item.TypeShears || hasSilkTouch(enchantments) {
 			return []item.Stack{item.NewStack(l, 1)}
 		}

--- a/server/block/melon.go
+++ b/server/block/melon.go
@@ -11,8 +11,11 @@ type Melon struct {
 
 // BreakInfo ...
 func (m Melon) BreakInfo() BreakInfo {
-	return newBreakInfo(1, alwaysHarvestable, axeEffective, discreteDrops(item.MelonSlice{}, m, 3, 7, 9))
+	return newBreakInfo(1, alwaysHarvestable, anyEffective(item.TypeAxe, item.TypeSword), discreteDrops(item.MelonSlice{}, m, 3, 7, 9))
 }
+
+// SwordMiningSpeed ...
+func (Melon) SwordMiningSpeed() float64 { return 1.5 }
 
 // CompostChance ...
 func (Melon) CompostChance() float64 {

--- a/server/block/moss_carpet.go
+++ b/server/block/moss_carpet.go
@@ -47,8 +47,11 @@ func (m MossCarpet) UseOnBlock(pos cube.Pos, face cube.Face, _ mgl64.Vec3, tx *w
 
 // BreakInfo ...
 func (m MossCarpet) BreakInfo() BreakInfo {
-	return newBreakInfo(0.1, alwaysHarvestable, nothingEffective, oneOf(m))
+	return newBreakInfo(0.1, alwaysHarvestable, swordEffective, oneOf(m))
 }
+
+// SwordMiningSpeed ...
+func (MossCarpet) SwordMiningSpeed() float64 { return 1.5 }
 
 // CompostChance ...
 func (MossCarpet) CompostChance() float64 {

--- a/server/block/pumpkin.go
+++ b/server/block/pumpkin.go
@@ -40,8 +40,11 @@ func (p Pumpkin) UseOnBlock(pos cube.Pos, face cube.Face, _ mgl64.Vec3, tx *worl
 
 // BreakInfo ...
 func (p Pumpkin) BreakInfo() BreakInfo {
-	return newBreakInfo(1, alwaysHarvestable, axeEffective, oneOf(p))
+	return newBreakInfo(1, alwaysHarvestable, anyEffective(item.TypeAxe, item.TypeSword), oneOf(p))
 }
+
+// SwordMiningSpeed ...
+func (Pumpkin) SwordMiningSpeed() float64 { return 1.5 }
 
 // CompostChance ...
 func (Pumpkin) CompostChance() float64 {

--- a/server/block/vine.go
+++ b/server/block/vine.go
@@ -50,8 +50,14 @@ func (Vines) FlammabilityInfo() FlammabilityInfo {
 func (v Vines) BreakInfo() BreakInfo {
 	return newBreakInfo(0.2, func(t item.Tool) bool {
 		return t.ToolType() == item.TypeShears
-	}, axeEffective, oneOf(v))
+	}, anyEffective(item.TypeAxe, item.TypeSword, item.TypeShears), oneOf(v))
 }
+
+// SwordMiningSpeed ...
+func (Vines) SwordMiningSpeed() float64 { return 1.5 }
+
+// ShearsMiningSpeed ...
+func (Vines) ShearsMiningSpeed() float64 { return 2 }
 
 // EntityInside ...
 func (Vines) EntityInside(_ cube.Pos, _ *world.Tx, e world.Entity) {

--- a/server/block/wool.go
+++ b/server/block/wool.go
@@ -29,6 +29,9 @@ func (w Wool) BreakInfo() BreakInfo {
 	return newBreakInfo(0.8, alwaysHarvestable, shearsEffective, oneOf(w))
 }
 
+// ShearsMiningSpeed ...
+func (Wool) ShearsMiningSpeed() float64 { return 5 }
+
 // EncodeItem ...
 func (w Wool) EncodeItem() (name string, meta int16) {
 	return "minecraft:" + w.Colour.String() + "_wool", 0

--- a/server/item/shears.go
+++ b/server/item/shears.go
@@ -43,9 +43,18 @@ func (s Shears) HarvestLevel() int {
 	return 1
 }
 
-// BaseMiningEfficiency ...
-func (s Shears) BaseMiningEfficiency(world.Block) float64 {
-	return 1.5
+// ShearsMineable is implemented by blocks that shears mine faster than a bare hand.
+type ShearsMineable interface {
+	// ShearsMiningSpeed returns the speed shears mine the block at.
+	ShearsMiningSpeed() float64
+}
+
+// BaseMiningEfficiency returns the speed the block passed names for shears, or 1 if it names none.
+func (s Shears) BaseMiningEfficiency(b world.Block) float64 {
+	if m, ok := b.(ShearsMineable); ok {
+		return m.ShearsMiningSpeed()
+	}
+	return 1
 }
 
 // DurabilityInfo ...

--- a/server/item/sword.go
+++ b/server/item/sword.go
@@ -38,12 +38,18 @@ func (s Sword) EnchantmentValue() int {
 	return s.Tier.EnchantmentValue
 }
 
-// BaseMiningEfficiency always returns 1.5, unless the block passed is cobweb, in which case 15 is returned.
+// SwordMineable is implemented by blocks that a sword mines faster than a bare hand.
+type SwordMineable interface {
+	// SwordMiningSpeed returns the speed a sword mines the block at.
+	SwordMiningSpeed() float64
+}
+
+// BaseMiningEfficiency returns the speed the block passed names for a sword, or 1 if it names none.
 func (s Sword) BaseMiningEfficiency(b world.Block) float64 {
-	if _, ok := b.(interface{ Cobweb() }); ok {
-		return 15
+	if m, ok := b.(SwordMineable); ok {
+		return m.SwordMiningSpeed()
 	}
-	return 1.5
+	return 1
 }
 
 // DurabilityInfo ...


### PR DESCRIPTION
Swords and shears each return a single number for every block: `1.5` from shears, and `1.5` from a sword except on cobweb. Bedrock decides their speed from the **block** instead — neither tool has a tier speed of its own the way a pickaxe does.

## Shears

Bedrock sorts blocks into three tiers for shears:

| speed | blocks |
| --- | --- |
| 15 | cobweb, leaves |
| 5 | wool |
| 2 | vines |

Everything else is 1. So shearing wool was more than three times too slow, and cutting leaves or cobweb ten times too slow. `minecraft.wiki` lists the same numbers under Bedrock breaking speed ("Wool: 5, Leaves: 15, Cobweb: 15").

## Swords

15 on cobweb, 30 on bamboo and bamboo saplings, and 1.5 on leaves, vines, moss carpet, pumpkins, melons and cocoa. Everything else is 1 — a sword is no faster than a bare hand on stone.

Only cobweb reached that before. The speed is gated on the block naming the tool effective in its `BreakInfo`, and no block other than cobweb named a sword, so the old `1.5` default was unreachable everywhere else.

## Shape

`BaseMiningEfficiency` asks the block, through two new interfaces:

```go
type SwordMineable interface{ SwordMiningSpeed() float64 }
type ShearsMineable interface{ ShearsMiningSpeed() float64 }
```

That keeps the numbers next to the block that owns them, alongside its hardness and harvestability, and leaves `BreakDuration` untouched. The blocks that answer also name the tool in their `Effective` predicate, which is what that predicate already means — "can be mined more effectively with the tool passed than with an empty hand" — and is true of a sword on leaves.

`anyEffective` is a small combinator for the blocks that now have two tool types, replacing the hand-written closures.

The resulting times line up with those published for Bedrock: wool with shears 0.25s, cobweb with shears 0.4s, leaves with shears 0.05s, leaves with a sword 0.2s against 0.3s bare-handed, and a pumpkin with a sword 1s.

## Not covered

Glow lichen, chorus plant, chorus flower and big dripleaf also take 1.5 from a sword in Bedrock. There are no such blocks yet, so there is nothing to hang the method on.
