### PR TITLE
block: expose client-visible container size

### DIFF
--- a/server/block/barrel.go
+++ b/server/block/barrel.go
@@ -50,6 +50,8 @@ func NewBarrel() Barrel {
 	}
 }
 
+func (Barrel) ContainerSize() int { return 27 }
+
 // Inventory returns the inventory of the barrel. The size of the inventory will be 27.
 func (b Barrel) Inventory(*world.Tx, cube.Pos) *inventory.Inventory {
 	return b.inventory

--- a/server/block/blast_furnace.go
+++ b/server/block/blast_furnace.go
@@ -25,6 +25,8 @@ type BlastFurnace struct {
 	Lit bool
 }
 
+func (BlastFurnace) ContainerSize() int { return 3 }
+
 // NewBlastFurnace creates a new initialised blast furnace. The smelter is properly initialised.
 func NewBlastFurnace(face cube.Direction) BlastFurnace {
 	return BlastFurnace{

--- a/server/block/brewing_stand.go
+++ b/server/block/brewing_stand.go
@@ -30,6 +30,8 @@ func NewBrewingStand() BrewingStand {
 	return BrewingStand{brewer: newBrewer()}
 }
 
+func (BrewingStand) ContainerSize() int { return 5 }
+
 // Model ...
 func (b BrewingStand) Model() world.BlockModel {
 	return model.BrewingStand{}

--- a/server/block/chest.go
+++ b/server/block/chest.go
@@ -55,6 +55,13 @@ func NewChest() Chest {
 	return c
 }
 
+func (c Chest) ContainerSize() int {
+	if c.paired {
+		return 54
+	}
+	return 27
+}
+
 // Inventory returns the inventory of the chest. The size of the inventory will be 27 or 54, depending on
 // whether the chest is single or double.
 func (c Chest) Inventory(tx *world.Tx, pos cube.Pos) *inventory.Inventory {

--- a/server/block/container.go
+++ b/server/block/container.go
@@ -27,4 +27,5 @@ type Container interface {
 	AddViewer(v ContainerViewer, tx *world.Tx, pos cube.Pos)
 	RemoveViewer(v ContainerViewer, tx *world.Tx, pos cube.Pos)
 	Inventory(tx *world.Tx, pos cube.Pos) *inventory.Inventory
+	ContainerSize() int
 }

--- a/server/block/decorated_pot.go
+++ b/server/block/decorated_pot.go
@@ -33,6 +33,8 @@ type DecoratedPot struct {
 	Decorations [4]PotDecoration
 }
 
+func (DecoratedPot) ContainerSize() int { return 1 }
+
 // SideClosed ...
 func (p DecoratedPot) SideClosed(cube.Pos, cube.Pos, *world.Tx) bool {
 	return false

--- a/server/block/ender_chest.go
+++ b/server/block/ender_chest.go
@@ -35,6 +35,8 @@ func NewEnderChest() EnderChest {
 	return EnderChest{viewers: &atomic.Int64{}}
 }
 
+func (EnderChest) ContainerSize() int { return 27 }
+
 // BreakInfo ...
 func (c EnderChest) BreakInfo() BreakInfo {
 	return newBreakInfo(22.5, pickaxeHarvestable, pickaxeEffective, silkTouchDrop(item.NewStack(Obsidian{}, 8), item.NewStack(NewEnderChest(), 1))).withBlastResistance(600)

--- a/server/block/furnace.go
+++ b/server/block/furnace.go
@@ -32,6 +32,8 @@ func NewFurnace(face cube.Direction) Furnace {
 	}
 }
 
+func (Furnace) ContainerSize() int { return 3 }
+
 // Tick is called to check if the furnace should update and start or stop smelting.
 func (f Furnace) Tick(_ int64, pos cube.Pos, tx *world.Tx) {
 	if f.Lit && rand.Float64() <= 0.016 { // Every three or so seconds.

--- a/server/block/hopper.go
+++ b/server/block/hopper.go
@@ -55,6 +55,8 @@ func NewHopper() Hopper {
 	}
 }
 
+func (Hopper) ContainerSize() int { return 5 }
+
 // Model ...
 func (Hopper) Model() world.BlockModel {
 	return model.Hopper{}

--- a/server/block/shulker_box.go
+++ b/server/block/shulker_box.go
@@ -71,6 +71,8 @@ func NewShulkerBox() ShulkerBox {
 	return s
 }
 
+func (ShulkerBox) ContainerSize() int { return 27 }
+
 // canStoreInShulkerBox rejects nested shulker boxes.
 func canStoreInShulkerBox(s item.Stack, _ int) bool {
 	if s.Empty() {

--- a/server/block/smoker.go
+++ b/server/block/smoker.go
@@ -25,6 +25,8 @@ type Smoker struct {
 	Lit bool
 }
 
+func (Smoker) ContainerSize() int { return 3 }
+
 // NewSmoker creates a new initialised smoker. The smelter is properly initialised.
 func NewSmoker(face cube.Direction) Smoker {
 	return Smoker{


### PR DESCRIPTION
## Summary

- Add `ContainerSize() int` to `block.Container` for reading a loaded block's client-visible inventory capacity without opening a world transaction.
- Expose fixed capacities for vanilla storage and workstation blocks.
- Preserve paired chest state so single and double chests report 27 and 54 slots respectively.