### PR TITLE
 server/entity: share the living-entity foundation with the player

### DIFF
--- a/server/entity/air_supply.go
+++ b/server/entity/air_supply.go
@@ -1,0 +1,75 @@
+package entity
+
+import (
+	"math/rand/v2"
+	"time"
+
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/item/enchantment"
+)
+
+// AirSupply keeps track of the air an entity has left while submerged, and whether it is currently able to
+// breathe. It implements the vanilla drowning cadence: air depletes by a tick's worth every tick without
+// air, a drowning hit lands once the supply is a second past empty, and air replenishes at five times the
+// depletion rate.
+type AirSupply struct {
+	supply, max time.Duration
+	breathing   bool
+}
+
+// NewAirSupply returns an AirSupply with the maximum air passed, full and breathing. A zero maximum uses
+// the vanilla default of 15 seconds.
+func NewAirSupply(max time.Duration) *AirSupply {
+	if max <= 0 {
+		max = time.Second * 15
+	}
+	return &AirSupply{supply: max, max: max, breathing: true}
+}
+
+// Supply returns the air the entity has left.
+func (a *AirSupply) Supply() time.Duration {
+	return a.supply
+}
+
+// SetSupply sets the air the entity has left.
+func (a *AirSupply) SetSupply(d time.Duration) {
+	a.supply = d
+}
+
+// Max returns the maximum air supply of the entity.
+func (a *AirSupply) Max() time.Duration {
+	return a.max
+}
+
+// SetMax sets the maximum air supply of the entity.
+func (a *AirSupply) SetMax(d time.Duration) {
+	a.max = d
+}
+
+// Breathing checks if the entity is currently breathing.
+func (a *AirSupply) Breathing() bool {
+	return a.breathing
+}
+
+// Tick progresses the air supply by one tick. The helmet passed may reduce air loss through its Respiration
+// enchantment. Tick returns whether the entity takes a drowning hit this tick and whether the state changed
+// in a way viewers should see.
+func (a *AirSupply) Tick(canBreathe bool, helmet item.Stack) (drowned, changed bool) {
+	if !canBreathe {
+		if r, ok := helmet.Enchantment(enchantment.Respiration); ok && rand.Float64() < enchantment.Respiration.Chance(r.Level()) {
+			return false, false
+		}
+		if a.supply -= time.Second / 20; a.supply <= -time.Second {
+			a.supply = 0
+			drowned = true
+		}
+		a.breathing = false
+		return drowned, true
+	}
+	if !a.breathing && a.supply < a.max {
+		a.supply = min(a.supply+time.Second/4, a.max)
+		a.breathing = a.supply == a.max
+		return false, true
+	}
+	return false, false
+}

--- a/server/entity/area_effect_cloud.go
+++ b/server/entity/area_effect_cloud.go
@@ -48,7 +48,7 @@ var AreaEffectCloudType areaEffectCloudType
 type areaEffectCloudType struct{}
 
 func (t areaEffectCloudType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (areaEffectCloudType) EncodeEntity() string { return "minecraft:area_effect_cloud" }

--- a/server/entity/area_effect_cloud_behaviour.go
+++ b/server/entity/area_effect_cloud_behaviour.go
@@ -93,9 +93,7 @@ func (a *AreaEffectCloudBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 
 	pos := e.Position()
 	if a.subtractTickRadius() {
-		for _, v := range tx.Viewers(pos) {
-			v.ViewEntityState(e)
-		}
+		e.UpdateState()
 	}
 
 	if (e.Age()/(time.Second/20))%10 != 0 {
@@ -109,9 +107,7 @@ func (a *AreaEffectCloudBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 		}
 	}
 	if a.applyEffects(pos, e, a.filter(tx.EntitiesWithin(e.H().Type().BBox(e).Translate(pos)))) {
-		for _, v := range tx.Viewers(pos) {
-			v.ViewEntityState(e)
-		}
+		e.UpdateState()
 	}
 	return nil
 }

--- a/server/entity/arrow.go
+++ b/server/entity/arrow.go
@@ -59,7 +59,7 @@ var ArrowType arrowType
 type arrowType struct{}
 
 func (t arrowType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (arrowType) EncodeEntity() string { return "minecraft:arrow" }

--- a/server/entity/arrow.go
+++ b/server/entity/arrow.go
@@ -45,14 +45,6 @@ var arrowConf = ProjectileBehaviourConfig{
 	SurviveBlockCollision: true,
 }
 
-// boolByte returns 1 if the bool passed is true, or 0 if it is false.
-func boolByte(b bool) uint8 {
-	if b {
-		return 1
-	}
-	return 0
-}
-
 // ArrowType is a world.EntityType implementation for Arrow.
 var ArrowType arrowType
 

--- a/server/entity/bottle_of_enchanting.go
+++ b/server/entity/bottle_of_enchanting.go
@@ -39,7 +39,7 @@ var BottleOfEnchantingType bottleOfEnchantingType
 type bottleOfEnchantingType struct{}
 
 func (t bottleOfEnchantingType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 // Glint returns true if the bottle should render with glint. It always returns

--- a/server/entity/collision.go
+++ b/server/entity/collision.go
@@ -1,0 +1,121 @@
+package entity
+
+import (
+	"math"
+
+	"github.com/df-mc/dragonfly/server/block"
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/block/model"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+// CheckEntityInsiders dispatches the block.EntityInsider hook of every block and liquid that the bounding
+// box passed intersects. The box is the entity's bounding box translated to its position.
+func CheckEntityInsiders(tx *world.Tx, e world.Entity, box cube.BBox) {
+	grown := box.Grow(-0.0001)
+	low, high := cube.PosFromVec3(grown.Min()), cube.PosFromVec3(grown.Max())
+
+	for y := low[1]; y <= high[1]; y++ {
+		for x := low[0]; x <= high[0]; x++ {
+			for z := low[2]; z <= high[2]; z++ {
+				blockPos := cube.Pos{x, y, z}
+				b := tx.Block(blockPos)
+				if collide, ok := b.(block.EntityInsider); ok {
+					collide.EntityInside(blockPos, tx, e)
+					if _, liquid := b.(world.Liquid); liquid {
+						continue
+					}
+				}
+				if l, ok := tx.Liquid(blockPos); ok {
+					if collide, ok := l.(block.EntityInsider); ok {
+						collide.EntityInside(blockPos, tx, e)
+					}
+				}
+			}
+		}
+	}
+}
+
+// CheckEntitySteppers dispatches the block.EntityStepper hook of the block that the bounding box passed
+// stands on. Callers only call it while the entity is on the ground.
+func CheckEntitySteppers(tx *world.Tx, e world.Entity, box cube.BBox) {
+	low, high := blocksUnderBox(box)
+	for x := low[0]; x <= high[0]; x++ {
+		for z := low[2]; z <= high[2]; z++ {
+			pos := cube.Pos{x, low[1], z}
+			if stepper, ok := tx.Block(pos).(block.EntityStepper); ok {
+				stepper.EntityStepOn(pos, tx, e)
+				return
+			}
+		}
+	}
+}
+
+// CheckEntityLanders dispatches the block.EntityLander hook of the block that the bounding box passed
+// lands on. The hook may change the fall distance passed.
+func CheckEntityLanders(tx *world.Tx, e world.Entity, box cube.BBox, distance float64) float64 {
+	low, high := blocksUnderBox(box)
+	for x := low[0]; x <= high[0]; x++ {
+		for z := low[2]; z <= high[2]; z++ {
+			pos := cube.Pos{x, low[1], z}
+			if l, ok := tx.Block(pos).(block.EntityLander); ok {
+				l.EntityLand(pos, tx, e, &distance)
+				return distance
+			}
+		}
+	}
+	return distance
+}
+
+// blocksUnderBox returns the corners of the range of block positions directly below the bounding box
+// passed. Every block in that range is one the entity stands on: the entity may be narrower than a block
+// and rest on the edge of one with its centre over the block beside it.
+func blocksUnderBox(box cube.BBox) (low, high cube.Pos) {
+	y := int(math.Floor(box.Min()[1] - 0.0001))
+	horizontal := box.Grow(-0.0001)
+	low, high = cube.PosFromVec3(horizontal.Min()), cube.PosFromVec3(horizontal.Max())
+	low[1], high[1] = y, y
+	return low, high
+}
+
+// breathingDistanceBelowEyes is the lowest distance an entity can be in water and still be able to breathe,
+// based on the entity's eye height.
+const breathingDistanceBelowEyes = 0.11111111
+
+// Submerged checks if the eyes of the entity passed are underwater.
+func Submerged(e world.Entity, tx *world.Tx) bool {
+	pos := cube.PosFromVec3(EyePosition(e))
+	if l, ok := tx.Liquid(pos); ok {
+		if _, ok := l.(block.Water); ok {
+			d := float64(l.SpreadDecay()) + 1
+			if l.LiquidFalling() {
+				d = 1
+			}
+			return e.Position()[1] < (pos.Side(cube.FaceUp).Vec3()[1])-(d/9-breathingDistanceBelowEyes)
+		}
+	}
+	return false
+}
+
+// InsideOfSolid checks if the entity passed is suffocating inside a solid block.
+func InsideOfSolid(e world.Entity, tx *world.Tx) bool {
+	pos := cube.PosFromVec3(EyePosition(e))
+	b, box := tx.Block(pos), e.H().Type().BBox(e).Translate(e.Position())
+
+	_, solid := b.Model().(model.Solid)
+	if !solid {
+		return false
+	}
+	if d, diffuses := b.(block.LightDiffuser); diffuses && d.LightDiffusionLevel() == 0 {
+		return false
+	}
+	if immune, ok := b.(block.NonSuffocating); ok && immune.PreventsSuffocation() {
+		return false
+	}
+	for _, blockBox := range b.Model().BBox(pos, tx) {
+		if blockBox.Translate(pos.Vec3()).IntersectsWith(box) {
+			return true
+		}
+	}
+	return false
+}

--- a/server/entity/collision.go
+++ b/server/entity/collision.go
@@ -6,7 +6,6 @@ import (
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/model"
-	"github.com/df-mc/dragonfly/server/entity/effect"
 	"github.com/df-mc/dragonfly/server/world"
 )
 
@@ -119,22 +118,4 @@ func InsideOfSolid(e world.Entity, tx *world.Tx) bool {
 		}
 	}
 	return false
-}
-
-// Fall lands an entity that fell the distance passed. The block landed on may soften the distance, a jump
-// boost effect reduces it further and the remainder is dealt as fall damage.
-func Fall(e interface {
-	world.Entity
-	Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool)
-}, tx *world.Tx, effects *EffectManager, distance float64) {
-	CheckEntityLanders(tx, e, e.H().Type().BBox(e).Translate(e.Position()), &distance)
-
-	dmg := distance - 3
-	if boost, ok := effects.Effect(effect.JumpBoost); ok {
-		dmg -= float64(boost.Level())
-	}
-	if dmg < 0.5 {
-		return
-	}
-	e.Hurt(math.Ceil(dmg), FallDamageSource{})
 }

--- a/server/entity/collision.go
+++ b/server/entity/collision.go
@@ -6,6 +6,7 @@ import (
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/model"
+	"github.com/df-mc/dragonfly/server/entity/effect"
 	"github.com/df-mc/dragonfly/server/world"
 )
 
@@ -118,4 +119,22 @@ func InsideOfSolid(e world.Entity, tx *world.Tx) bool {
 		}
 	}
 	return false
+}
+
+// Fall lands an entity that fell the distance passed. The block landed on may soften the distance, a jump
+// boost effect reduces it further and the remainder is dealt as fall damage.
+func Fall(e interface {
+	world.Entity
+	Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool)
+}, tx *world.Tx, effects *EffectManager, distance float64) {
+	CheckEntityLanders(tx, e, e.H().Type().BBox(e).Translate(e.Position()), &distance)
+
+	dmg := distance - 3
+	if boost, ok := effects.Effect(effect.JumpBoost); ok {
+		dmg -= float64(boost.Level())
+	}
+	if dmg < 0.5 {
+		return
+	}
+	e.Hurt(math.Ceil(dmg), FallDamageSource{})
 }

--- a/server/entity/combat.go
+++ b/server/entity/combat.go
@@ -1,0 +1,58 @@
+package entity
+
+import (
+	"math"
+
+	"github.com/df-mc/dragonfly/server/entity/effect"
+	"github.com/df-mc/dragonfly/server/item/inventory"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/go-gl/mathgl/mgl64"
+)
+
+// KnockBackVector returns the velocity that knocks back an entity at pos away from src with the force and
+// height passed.
+func KnockBackVector(pos, src mgl64.Vec3, force, height float64) mgl64.Vec3 {
+	velocity := pos.Sub(src)
+	velocity[1] = 0
+
+	if velocity.Len() != 0 {
+		velocity = velocity.Normalize().Mul(force)
+	}
+	velocity[1] = height
+	return velocity
+}
+
+// ExplosionDamage returns the damage an explosion of the size passed deals to an entity exposed to it with
+// the impact passed, following the vanilla formula.
+func ExplosionDamage(size, impact float64) float64 {
+	return math.Floor((impact*impact+impact)*3.5*size*2 + 1)
+}
+
+// FinalDamage returns the damage dealt to an entity after the armour worn and an active resistance effect
+// reduced the damage passed.
+func FinalDamage(dmg float64, src world.DamageSource, armour *inventory.Armour, effects *EffectManager) float64 {
+	dmg = max(dmg, 0)
+	dmg -= armour.DamageReduction(dmg, src)
+	if res, ok := effects.Effect(effect.Resistance); ok {
+		dmg *= effect.Resistance.Multiplier(src, res.Level())
+	}
+	return dmg
+}
+
+// Fall lands an entity that fell the distance passed. The block landed on may soften the distance, a jump
+// boost effect reduces it further and the remainder is dealt as fall damage.
+func Fall(e interface {
+	world.Entity
+	Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool)
+}, tx *world.Tx, effects *EffectManager, distance float64) {
+	CheckEntityLanders(tx, e, e.H().Type().BBox(e).Translate(e.Position()), &distance)
+
+	dmg := distance - 3
+	if boost, ok := effects.Effect(effect.JumpBoost); ok {
+		dmg -= float64(boost.Level())
+	}
+	if dmg < 0.5 {
+		return
+	}
+	e.Hurt(math.Ceil(dmg), FallDamageSource{})
+}

--- a/server/entity/combat.go
+++ b/server/entity/combat.go
@@ -41,11 +41,8 @@ func FinalDamage(dmg float64, src world.DamageSource, armour *inventory.Armour, 
 
 // Fall lands an entity that fell the distance passed. The block landed on may soften the distance, a jump
 // boost effect reduces it further and the remainder is dealt as fall damage.
-func Fall(e interface {
-	world.Entity
-	Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool)
-}, tx *world.Tx, effects *EffectManager, distance float64) {
-	CheckEntityLanders(tx, e, e.H().Type().BBox(e).Translate(e.Position()), &distance)
+func Fall(e Hurtable, tx *world.Tx, effects *EffectManager, distance float64) {
+	distance = CheckEntityLanders(tx, e, e.H().Type().BBox(e).Translate(e.Position()), distance)
 
 	dmg := distance - 3
 	if boost, ok := effects.Effect(effect.JumpBoost); ok {

--- a/server/entity/damageable.go
+++ b/server/entity/damageable.go
@@ -12,9 +12,11 @@ type Hurtable interface {
 	Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool)
 }
 
-// behaviourDamageable represents a Behaviour that may be hurt directly without
-// implementing Living.
-type behaviourDamageable interface {
+// DamageableBehaviour may be implemented by a Behaviour to let its entity take damage without implementing
+// the full Living interface. HurtEntity and Ent.Hurt dispatch to it.
+type DamageableBehaviour interface {
+	// Hurt hurts the entity of the Behaviour. It returns the damage dealt and whether the entity was
+	// vulnerable to it.
 	Hurt(e *Ent, damage float64, src world.DamageSource) (n float64, vulnerable bool)
 }
 
@@ -28,7 +30,7 @@ func HurtEntity(e world.Entity, damage float64, src world.DamageSource) (n float
 	}
 	if w, ok := e.(wrappedEnt); ok {
 		ent := w.Unwrap()
-		if d, ok := ent.Behaviour().(behaviourDamageable); ok {
+		if d, ok := ent.Behaviour().(DamageableBehaviour); ok {
 			n, vulnerable = d.Hurt(ent, damage, src)
 			return n, vulnerable, true
 		}
@@ -42,7 +44,7 @@ func DamageableEntity(e world.Entity) bool {
 		return true
 	}
 	if w, ok := e.(wrappedEnt); ok {
-		_, ok = w.Unwrap().Behaviour().(behaviourDamageable)
+		_, ok = w.Unwrap().Behaviour().(DamageableBehaviour)
 		return ok
 	}
 	return false

--- a/server/entity/damageable.go
+++ b/server/entity/damageable.go
@@ -34,8 +34,8 @@ func HurtEntity(e world.Entity, damage float64, src world.DamageSource) (n float
 	}
 	if w, ok := e.(wrappedEnt); ok {
 		ent := w.Unwrap()
-		if d, ok := ent.Behaviour().(DamageableBehaviour); ok {
-			n, vulnerable = d.Hurt(ent, damage, src)
+		if _, ok := ent.Behaviour().(DamageableBehaviour); ok {
+			n, vulnerable = ent.Hurt(damage, src)
 			return n, vulnerable, true
 		}
 	}

--- a/server/entity/damageable.go
+++ b/server/entity/damageable.go
@@ -26,7 +26,8 @@ func HurtEntity(e world.Entity, damage float64, src world.DamageSource) (n float
 		n, vulnerable = l.Hurt(damage, src)
 		return n, vulnerable, true
 	}
-	if ent, ok := e.(*Ent); ok {
+	if w, ok := e.(wrappedEnt); ok {
+		ent := w.Unwrap()
 		if d, ok := ent.Behaviour().(behaviourDamageable); ok {
 			n, vulnerable = d.Hurt(ent, damage, src)
 			return n, vulnerable, true
@@ -40,8 +41,8 @@ func DamageableEntity(e world.Entity) bool {
 	if _, ok := e.(Living); ok {
 		return true
 	}
-	if ent, ok := e.(*Ent); ok {
-		_, ok = ent.Behaviour().(behaviourDamageable)
+	if w, ok := e.(wrappedEnt); ok {
+		_, ok = w.Unwrap().Behaviour().(behaviourDamageable)
 		return ok
 	}
 	return false

--- a/server/entity/damageable.go
+++ b/server/entity/damageable.go
@@ -1,6 +1,10 @@
 package entity
 
-import "github.com/df-mc/dragonfly/server/world"
+import (
+	"iter"
+
+	"github.com/df-mc/dragonfly/server/world"
+)
 
 // Hurtable is a world.Entity that may be hurt directly. It is the least the
 // shared damage helpers need of an entity, and is deliberately smaller than
@@ -48,4 +52,19 @@ func DamageableEntity(e world.Entity) bool {
 		return ok
 	}
 	return false
+}
+
+// filterDamageable filters an entity sequence down to the entities that may be damaged, as reported by
+// DamageableEntity.
+func filterDamageable(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
+	return func(yield func(world.Entity) bool) {
+		for e := range seq {
+			if !DamageableEntity(e) {
+				continue
+			}
+			if !yield(e) {
+				return
+			}
+		}
+	}
 }

--- a/server/entity/damageable.go
+++ b/server/entity/damageable.go
@@ -33,7 +33,7 @@ func HurtEntity(e world.Entity, damage float64, src world.DamageSource) (n float
 		return n, vulnerable, true
 	}
 	if w, ok := e.(wrappedEnt); ok {
-		ent := w.Unwrap()
+		ent := w.Base()
 		if _, ok := ent.Behaviour().(DamageableBehaviour); ok {
 			n, vulnerable = ent.Hurt(damage, src)
 			return n, vulnerable, true
@@ -48,7 +48,7 @@ func DamageableEntity(e world.Entity) bool {
 		return true
 	}
 	if w, ok := e.(wrappedEnt); ok {
-		_, ok = w.Unwrap().Behaviour().(DamageableBehaviour)
+		_, ok = w.Base().Behaviour().(DamageableBehaviour)
 		return ok
 	}
 	return false

--- a/server/entity/damageable.go
+++ b/server/entity/damageable.go
@@ -2,6 +2,16 @@ package entity
 
 import "github.com/df-mc/dragonfly/server/world"
 
+// Hurtable is a world.Entity that may be hurt directly. It is the least the
+// shared damage helpers need of an entity, and is deliberately smaller than
+// Damageable: a falling or burning entity need not carry health of its own.
+type Hurtable interface {
+	world.Entity
+	// Hurt hurts the entity for the damage passed. It returns the damage dealt
+	// and whether the entity was vulnerable to it.
+	Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool)
+}
+
 // behaviourDamageable represents a Behaviour that may be hurt directly without
 // implementing Living.
 type behaviourDamageable interface {

--- a/server/entity/doc.go
+++ b/server/entity/doc.go
@@ -1,0 +1,72 @@
+// Package entity implements the entities that inhabit a world, along with the machinery to build new ones,
+// both inside this package and in external modules.
+//
+// # Architecture
+//
+// Three types work together to form an entity:
+//
+//   - A world.EntityType is the identity of an entity kind. It creates the entity's live
+//     form through its Open method and encodes/decodes its data to NBT.
+//   - A world.EntityHandle is the persistent form of one entity. It owns the entity's world.EntityData and
+//     outlives transactions, worlds and restarts.
+//   - An Ent is the live form of an entity inside a single world.Tx. It is cheap and short-lived: it is
+//     recreated through EntityType.Open for every transaction that touches the entity.
+//
+// Because an Ent only lives for one transaction, an entity's state must never be stored on it. All state is
+// held by the entity's Behaviour, which is stored in world.EntityData.Data and travels with the handle. The
+// Behaviour's Tick drives the entity and returns a *Movement describing how it moved, which the Ent sends to
+// viewers.
+//
+// # Behaviours
+//
+// This package provides behaviours for common entity archetypes: PassiveBehaviour for entities that are
+// pushed around by the environment, ProjectileBehaviour for entities that fly and hit, StationaryBehaviour
+// for entities that stay put, and specialised behaviours built on them. Each behaviour is created from its
+// XBehaviourConfig through New, and each config's Apply method stores a new behaviour in a
+// world.EntityData, so configs may be passed to world.EntitySpawnOpts.New directly.
+//
+// Behaviours advertise optional abilities to the rest of the server by implementing extension interfaces,
+// discovered by type assertion on the Behaviour:
+//
+//   - DamageableBehaviour lets an entity take damage without being alive. HurtEntity and Ent.Hurt
+//     dispatch to it.
+//   - ExplodableBehaviour lets an entity react to explosions. Ent.Explode dispatches to it.
+//   - PortalTravelHandler and PortalTravelComputerProvider hook an entity into portal travel; embedding
+//     BaseBehaviour provides the latter.
+//   - LivingHurtHandler and LivingDeathHandler let a LivingBehaviour intercept damage and death.
+//
+// # Living entities
+//
+// A living entity is built by implementing LivingBehaviour: a Behaviour that exposes a
+// LivingState holding its state: health, effects, armour, held items, air, fall distance and appearance.
+// The entity type's Open method returns OpenLiving(tx, handle, data), and the resulting LivingEnt
+// implements Living. Everything gated on Living then works out of the box: the full player attack path
+// with enchantments and critical hits, projectile knock back, potion effects, attack immunity with the
+// vanilla excess-damage rule, vanilla explosion damage, damage reduction, thorns and durability of worn
+// armour, burning, drowning, suffocation, void and fall damage, the contact hooks of blocks stood in or
+// on, and a death deferred to the next tick so drops can be spawned within a transaction. Worn armour and
+// held items are shown to viewers, as are the scale, baby, variant and breathing state of the LivingState.
+//
+// AI is deliberately not part of this package: it is built in external
+// modules on top of LivingBehaviour, which drive their entities by returning a Movement from Tick and by
+// reporting motion through LivingEnt.UpdateFallState.
+//
+// # Building entities outside this package
+//
+// An external module defines its own world.EntityType and Behaviour. A behaviour that runs its own physics
+// returns NewMovement(e, pos, vel, rot, onGround) from Tick to move its entity; to reuse this package's
+// gravity, drag and collision it may run MovementComputer.TickMovement first and feed the resulting
+// Position and Velocity into NewMovement. It broadcasts animations with Ent.PlayAction and resends metadata
+// with Ent.UpdateState after changing state it reports. A behaviour contributes raw metadata values to
+// viewers by implementing EncodeEntityMetadata(m map[uint32]any). Damage to
+// arbitrary entities is dealt through HurtEntity, and DamageableEntity reports whether an entity can take
+// damage at all.
+//
+// The DecodeNBT method of a world.EntityType must always store a Behaviour in the world.EntityData passed,
+// like its Open-time config does: an entity loaded from disk is otherwise opened without a Behaviour and
+// panics on first use.
+//
+// For a server to spawn custom entity types, they must be part of its world.EntityRegistry:
+//
+//	reg := entity.DefaultRegistry.Config().New(append(entity.DefaultRegistry.Types(), custom.Type))
+package entity

--- a/server/entity/doc.go
+++ b/server/entity/doc.go
@@ -60,7 +60,7 @@
 // with Ent.UpdateState after changing state it reports. A behaviour contributes raw metadata values to
 // viewers by implementing EncodeEntityMetadata(m map[uint32]any). Damage to
 // arbitrary entities is dealt through HurtEntity, and DamageableEntity reports whether an entity can take
-// damage at all.
+// damage at all. The world's Handler may change or cancel damage to any entity through HandleEntityHurt.
 //
 // The DecodeNBT method of a world.EntityType must always store a Behaviour in the world.EntityData passed,
 // like its Open-time config does: an entity loaded from disk is otherwise opened without a Behaviour and

--- a/server/entity/egg.go
+++ b/server/entity/egg.go
@@ -28,7 +28,7 @@ var EggType eggType
 type eggType struct{}
 
 func (t eggType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (eggType) EncodeEntity() string { return "minecraft:egg" }

--- a/server/entity/ender_pearl.go
+++ b/server/entity/ender_pearl.go
@@ -52,7 +52,7 @@ var EnderPearlType enderPearlType
 type enderPearlType struct{}
 
 func (t enderPearlType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (enderPearlType) EncodeEntity() string { return "minecraft:ender_pearl" }

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -73,10 +73,15 @@ type wrappedEnt interface {
 // entity as invulnerable otherwise. It gives entities that are damageable without being alive the same Hurt
 // method surface that code dealing damage asserts on Living entities.
 func (e *Ent) Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool) {
-	if d, ok := e.Behaviour().(DamageableBehaviour); ok {
-		return d.Hurt(e, damage, src)
+	d, ok := e.Behaviour().(DamageableBehaviour)
+	if !ok {
+		return 0, false
 	}
-	return 0, false
+	ctx := e.tx.Event()
+	if e.tx.World().Handler().HandleEntityHurt(ctx, e, &damage, src); ctx.Cancelled() {
+		return 0, false
+	}
+	return d.Hurt(e, damage, src)
 }
 
 // ExplodableBehaviour may be implemented by a Behaviour to react to an explosion hitting its entity.

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -45,6 +45,19 @@ func (e *Ent) Behaviour() Behaviour {
 	return b
 }
 
+// Tx returns the transaction the entity was opened in.
+func (e *Ent) Tx() *world.Tx {
+	return e.tx
+}
+
+// Data returns the entity data of the entity's handle, the state that persists across transactions. It is
+// writable, and writing to it is not the same as moving the entity: setting Pos or Vel here changes where the
+// entity is without telling anyone watching it, so a viewer keeps drawing it where it was. Move an entity
+// through its Movement instead, and reach for this only for state no method covers.
+func (e *Ent) Data() *world.EntityData {
+	return e.data
+}
+
 // Unwrap returns the Ent itself. It is promoted by entities that embed Ent, so that the underlying Ent can
 // be recognised wherever behaviour hooks are dispatched.
 func (e *Ent) Unwrap() *Ent {

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -52,21 +52,26 @@ type wrappedEnt interface {
 	Unwrap() *Ent
 }
 
-// Hurt dispatches damage to the entity's Behaviour if it implements the behaviourDamageable Hurt method
+// Hurt dispatches damage to the entity's Behaviour if it implements the DamageableBehaviour Hurt method
 // and reports the entity as invulnerable otherwise. Blocks dealing environmental damage assert this method,
 // so it makes entities such as end crystals vulnerable to them without implementing Living.
 func (e *Ent) Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool) {
-	if d, ok := e.Behaviour().(behaviourDamageable); ok {
+	if d, ok := e.Behaviour().(DamageableBehaviour); ok {
 		return d.Hurt(e, damage, src)
 	}
 	return 0, false
 }
 
+// ExplodableBehaviour may be implemented by a Behaviour to react to an explosion hitting its entity, for
+// example by being blasted away or by exploding too. Ent.Explode dispatches to it.
+type ExplodableBehaviour interface {
+	// Explode reacts to an explosion with the source and the impact on the entity passed.
+	Explode(e *Ent, src world.ExplosionSource, impact float64)
+}
+
 // Explode propagates the explosion behaviour of the underlying Behaviour.
 func (e *Ent) Explode(src world.ExplosionSource, impact float64) {
-	if expl, ok := e.Behaviour().(interface {
-		Explode(e *Ent, src world.ExplosionSource, impact float64)
-	}); ok {
+	if expl, ok := e.Behaviour().(ExplodableBehaviour); ok {
 		expl.Explode(e, src, impact)
 	}
 }
@@ -226,7 +231,7 @@ func (e *Ent) TravelThroughPortal(tx *world.Tx, target world.Dimension) {
 
 // portalTravelComputer returns the behaviour's portal travel state, if any.
 func (e *Ent) portalTravelComputer() *PortalTravelComputer {
-	if b, ok := e.Behaviour().(portalTravelComputerProvider); ok {
+	if b, ok := e.Behaviour().(PortalTravelComputerProvider); ok {
 		return b.PortalTravelComputer()
 	}
 	return nil

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -280,3 +280,11 @@ func (e *Ent) checkPortalInsiders() bool {
 	}
 	return false
 }
+
+// boolByte returns 1 if the bool passed is true, or 0 if it is false.
+func boolByte(b bool) uint8 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -58,15 +58,15 @@ func (e *Ent) Data() *world.EntityData {
 	return e.data
 }
 
-// Unwrap returns the Ent itself. It is promoted by entities that embed Ent, so that the underlying Ent can
-// be recognised wherever behaviour hooks are dispatched.
-func (e *Ent) Unwrap() *Ent {
+// Base returns the Ent itself. It is promoted by entities that embed Ent, so that the underlying Ent can be
+// recognised wherever behaviour hooks are dispatched.
+func (e *Ent) Base() *Ent {
 	return e
 }
 
 // wrappedEnt is implemented by any entity carrying an Ent: the Ent itself or a struct embedding it.
 type wrappedEnt interface {
-	Unwrap() *Ent
+	Base() *Ent
 }
 
 // Hurt dispatches damage to the entity's Behaviour if it implements DamageableBehaviour and reports the

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -17,9 +17,9 @@ type Behaviour interface {
 	Tick(e *Ent, tx *world.Tx) *Movement
 }
 
-// Ent is a world.Entity implementation that allows entity implementations to
-// share a lot of code. It is currently under development and is prone to
-// (breaking) changes.
+// Ent is the live form of an entity within a single world.Tx: it is recreated through a world.EntityType's
+// Open method for every transaction that touches the entity. It carries the base plumbing shared by all
+// entity implementations. Persistent state must live in the entity's Behaviour, never in the Ent itself.
 type Ent struct {
 	tx                *world.Tx
 	handle            *world.EntityHandle
@@ -33,16 +33,18 @@ func Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) *Ent
 	return &Ent{tx: tx, handle: handle, data: data}
 }
 
+// H returns the world.EntityHandle of the entity: its persistent form that outlives the transaction.
 func (e *Ent) H() *world.EntityHandle {
 	return e.handle
 }
 
+// Behaviour returns the Behaviour of the entity, stored in the entity data of its handle.
 func (e *Ent) Behaviour() Behaviour {
 	return e.data.Data.(Behaviour)
 }
 
-// Unwrap returns the Ent itself. It is promoted by entities that embed Ent, such as LivingEnt, so that the
-// underlying Ent can be recognised wherever behaviour hooks are dispatched.
+// Unwrap returns the Ent itself. It is promoted by entities that embed Ent, so that the underlying Ent can
+// be recognised wherever behaviour hooks are dispatched.
 func (e *Ent) Unwrap() *Ent {
 	return e
 }
@@ -52,9 +54,9 @@ type wrappedEnt interface {
 	Unwrap() *Ent
 }
 
-// Hurt dispatches damage to the entity's Behaviour if it implements the DamageableBehaviour Hurt method
-// and reports the entity as invulnerable otherwise. Blocks dealing environmental damage assert this method,
-// so it makes entities such as end crystals vulnerable to them without implementing Living.
+// Hurt dispatches damage to the entity's Behaviour if it implements DamageableBehaviour and reports the
+// entity as invulnerable otherwise. It gives entities that are damageable without being alive the same Hurt
+// method surface that code dealing damage asserts on Living entities.
 func (e *Ent) Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool) {
 	if d, ok := e.Behaviour().(DamageableBehaviour); ok {
 		return d.Hurt(e, damage, src)
@@ -62,8 +64,8 @@ func (e *Ent) Hurt(damage float64, src world.DamageSource) (n float64, vulnerabl
 	return 0, false
 }
 
-// ExplodableBehaviour may be implemented by a Behaviour to react to an explosion hitting its entity, for
-// example by being blasted away or by exploding too. Ent.Explode dispatches to it.
+// ExplodableBehaviour may be implemented by a Behaviour to react to an explosion hitting its entity.
+// Ent.Explode dispatches to it.
 type ExplodableBehaviour interface {
 	// Explode reacts to an explosion with the source and the impact on the entity passed.
 	Explode(e *Ent, src world.ExplosionSource, impact float64)
@@ -190,8 +192,11 @@ func (e *Ent) Tick(tx *world.Tx, current int64) {
 
 	y := e.data.Pos[1]
 	if y < float64(tx.Range()[0]) && current%10 == 0 {
-		_ = e.Close()
-		return
+		// Living entities are hurt by the void in LivingEnt.Tick instead of vanishing silently.
+		if _, living := e.Behaviour().(LivingBehaviour); !living {
+			_ = e.Close()
+			return
+		}
 	}
 	e.SetOnFire(e.OnFireDuration() - time.Second/20)
 

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -38,9 +38,11 @@ func (e *Ent) H() *world.EntityHandle {
 	return e.handle
 }
 
-// Behaviour returns the Behaviour of the entity, stored in the entity data of its handle.
+// Behaviour returns the Behaviour of the entity, stored in the entity data of its handle. Nil is returned
+// if the entity data holds no Behaviour.
 func (e *Ent) Behaviour() Behaviour {
-	return e.data.Data.(Behaviour)
+	b, _ := e.data.Data.(Behaviour)
+	return b
 }
 
 // Unwrap returns the Ent itself. It is promoted by entities that embed Ent, so that the underlying Ent can

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -41,6 +41,27 @@ func (e *Ent) Behaviour() Behaviour {
 	return e.data.Data.(Behaviour)
 }
 
+// Unwrap returns the Ent itself. It is promoted by entities that embed Ent, such as LivingEnt, so that the
+// underlying Ent can be recognised wherever behaviour hooks are dispatched.
+func (e *Ent) Unwrap() *Ent {
+	return e
+}
+
+// wrappedEnt is implemented by any entity carrying an Ent: the Ent itself or a struct embedding it.
+type wrappedEnt interface {
+	Unwrap() *Ent
+}
+
+// Hurt dispatches damage to the entity's Behaviour if it implements the behaviourDamageable Hurt method
+// and reports the entity as invulnerable otherwise. Blocks dealing environmental damage assert this method,
+// so it makes entities such as end crystals vulnerable to them without implementing Living.
+func (e *Ent) Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool) {
+	if d, ok := e.Behaviour().(behaviourDamageable); ok {
+		return d.Hurt(e, damage, src)
+	}
+	return 0, false
+}
+
 // Explode propagates the explosion behaviour of the underlying Behaviour.
 func (e *Ent) Explode(src world.ExplosionSource, impact float64) {
 	if expl, ok := e.Behaviour().(interface {

--- a/server/entity/ent.go
+++ b/server/entity/ent.go
@@ -134,10 +134,23 @@ func (e *Ent) SetAlwaysShowNameTag(alwaysShow bool) {
 	e.updateState()
 }
 
+// UpdateState resends the entity's metadata to all viewers of the entity. Behaviours call it after changing
+// state that is reflected in entity metadata.
+func (e *Ent) UpdateState() {
+	e.updateState()
+}
+
 // updateState updates the state of the entity for all viewers of the entity.
 func (e *Ent) updateState() {
 	for _, v := range e.tx.Viewers(e.data.Pos) {
 		v.ViewEntityState(e)
+	}
+}
+
+// PlayAction plays a world.EntityAction for all viewers of the entity.
+func (e *Ent) PlayAction(a world.EntityAction) {
+	for _, v := range e.tx.Viewers(e.data.Pos) {
+		v.ViewEntityAction(e, a)
 	}
 }
 

--- a/server/entity/experience.go
+++ b/server/entity/experience.go
@@ -89,7 +89,7 @@ func progressFromExperience(experience float64) (level int, progress float64) {
 	var sol float64
 	if d := b*b - 4*a*(c-experience); d > 0 {
 		s := math.Sqrt(d)
-		sol = math.Max((-b+s)/(2*a), (-b-s)/(2*a))
+		sol = max((-b+s)/(2*a), (-b-s)/(2*a))
 	} else if d == 0 {
 		sol = -b / (2 * a)
 	}

--- a/server/entity/experience_orb.go
+++ b/server/entity/experience_orb.go
@@ -47,7 +47,7 @@ var ExperienceOrbType experienceOrbType
 type experienceOrbType struct{}
 
 func (t experienceOrbType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (experienceOrbType) EncodeEntity() string { return "minecraft:xp_orb" }

--- a/server/entity/falling_block.go
+++ b/server/entity/falling_block.go
@@ -24,7 +24,7 @@ var FallingBlockType fallingBlockType
 type fallingBlockType struct{}
 
 func (t fallingBlockType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 func (fallingBlockType) EncodeEntity() string   { return "minecraft:falling_block" }
 func (fallingBlockType) NetworkOffset() float64 { return 0.49 }

--- a/server/entity/falling_block_behaviour.go
+++ b/server/entity/falling_block_behaviour.go
@@ -101,8 +101,8 @@ func (f *FallingBlockBehaviour) damageEntities(e *Ent, d damager, pos mgl64.Vec3
 	dmg := math.Min(math.Floor(dist*damagePerBlock), maxDamage)
 	src := block.DamageSource{Block: f.block}
 
-	for e := range filterLiving(tx.EntitiesWithin(e.H().Type().BBox(e).Translate(pos).Grow(0.05))) {
-		e.(Living).Hurt(dmg, src)
+	for e := range filterDamageable(tx.EntitiesWithin(e.H().Type().BBox(e).Translate(pos).Grow(0.05))) {
+		HurtEntity(e, dmg, src)
 	}
 	if b, ok := f.block.(breakable); ok && dmg > 0.0 && rand.Float64() < (dist+1)*0.05 {
 		f.block = b.Break()

--- a/server/entity/falling_block_behaviour.go
+++ b/server/entity/falling_block_behaviour.go
@@ -98,7 +98,7 @@ func (f *FallingBlockBehaviour) damageEntities(e *Ent, d damager, pos mgl64.Vec3
 	if dist <= 0 {
 		return
 	}
-	dmg := math.Min(math.Floor(dist*damagePerBlock), maxDamage)
+	dmg := min(math.Floor(dist*damagePerBlock), maxDamage)
 	src := block.DamageSource{Block: f.block}
 
 	for e := range filterDamageable(tx.EntitiesWithin(e.H().Type().BBox(e).Translate(pos).Grow(0.05))) {

--- a/server/entity/firework.go
+++ b/server/entity/firework.go
@@ -40,7 +40,7 @@ var FireworkType fireworkType
 type fireworkType struct{}
 
 func (t fireworkType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (fireworkType) EncodeEntity() string        { return "minecraft:fireworks_rocket" }

--- a/server/entity/firework_behaviour.go
+++ b/server/entity/firework_behaviour.go
@@ -98,9 +98,7 @@ func (f *FireworkBehaviour) explode(e *Ent, tx *world.Tx) {
 	owner, _ := f.conf.Owner.Entity(tx)
 	pos, explosions := e.Position(), f.conf.Firework.Explosions
 
-	for _, v := range tx.Viewers(pos) {
-		v.ViewEntityAction(e, FireworkExplosionAction{})
-	}
+	e.PlayAction(FireworkExplosionAction{})
 	for _, explosion := range explosions {
 		if explosion.Shape == item.FireworkShapeHugeSphere() {
 			tx.PlaySound(pos, sound.FireworkHugeBlast{})

--- a/server/entity/firework_behaviour.go
+++ b/server/entity/firework_behaviour.go
@@ -5,7 +5,6 @@ import (
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/df-mc/dragonfly/server/world/sound"
-	"iter"
 	"math"
 	"time"
 )
@@ -131,34 +130,6 @@ func (f *FireworkBehaviour) explode(e *Ent, tx *world.Tx) {
 		}
 		if _, ok := trace.Perform(pos, tpos, tx, victim.H().Type().BBox(victim).Grow(0.3), nil); ok {
 			HurtEntity(victim, dmg, src)
-		}
-	}
-}
-
-// filterDamageable filters an entity sequence down to the entities that may be damaged, as reported by
-// DamageableEntity.
-func filterDamageable(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
-	return func(yield func(world.Entity) bool) {
-		for e := range seq {
-			if !DamageableEntity(e) {
-				continue
-			}
-			if !yield(e) {
-				return
-			}
-		}
-	}
-}
-
-func filterLiving(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
-	return func(yield func(world.Entity) bool) {
-		for e := range seq {
-			if _, living := e.(Living); !living {
-				continue
-			}
-			if !yield(e) {
-				return
-			}
 		}
 	}
 }

--- a/server/entity/firework_behaviour.go
+++ b/server/entity/firework_behaviour.go
@@ -117,7 +117,7 @@ func (f *FireworkBehaviour) explode(e *Ent, tx *world.Tx) {
 	}
 
 	force := float64(len(explosions)*2) + 5.0
-	for victim := range filterLiving(tx.EntitiesWithin(e.H().Type().BBox(e).Translate(pos).Grow(5.25))) {
+	for victim := range filterDamageable(tx.EntitiesWithin(e.H().Type().BBox(e).Translate(pos).Grow(5.25))) {
 		tpos := victim.Position()
 		dist := pos.Sub(tpos).Len()
 		if dist > 5.0 {
@@ -128,11 +128,26 @@ func (f *FireworkBehaviour) explode(e *Ent, tx *world.Tx) {
 		src := ProjectileDamageSource{Owner: owner, Projectile: e}
 
 		if pos == tpos {
-			victim.(Living).Hurt(dmg, src)
+			HurtEntity(victim, dmg, src)
 			continue
 		}
 		if _, ok := trace.Perform(pos, tpos, tx, victim.H().Type().BBox(victim).Grow(0.3), nil); ok {
-			victim.(Living).Hurt(dmg, src)
+			HurtEntity(victim, dmg, src)
+		}
+	}
+}
+
+// filterDamageable filters an entity sequence down to the entities that may be damaged, as reported by
+// DamageableEntity.
+func filterDamageable(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
+	return func(yield func(world.Entity) bool) {
+		for e := range seq {
+			if !DamageableEntity(e) {
+				continue
+			}
+			if !yield(e) {
+				return
+			}
 		}
 	}
 }

--- a/server/entity/flammable.go
+++ b/server/entity/flammable.go
@@ -1,6 +1,12 @@
 package entity
 
-import "time"
+import (
+	"time"
+
+	"github.com/df-mc/dragonfly/server/block"
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+)
 
 // Flammable is an interface for entities that can be set on fire.
 type Flammable interface {
@@ -10,4 +16,26 @@ type Flammable interface {
 	SetOnFire(duration time.Duration)
 	// Extinguish extinguishes the entity.
 	Extinguish()
+}
+
+// TickOnFire progresses the burning of an entity by one tick: rain extinguishes it and every full second
+// FlammableEntity is a Hurtable that can catch fire, which is what the shared
+// fire tick works on.
+type FlammableEntity interface {
+	Hurtable
+	Flammable
+}
+
+// of remaining fire time deals a point of fire damage.
+func TickOnFire(e FlammableEntity, tx *world.Tx) {
+	if e.OnFireDuration() <= 0 {
+		return
+	}
+	if tx.RainingAt(cube.PosFromVec3(e.Position())) {
+		e.Extinguish()
+		return
+	}
+	if e.OnFireDuration()%time.Second == 0 {
+		e.Hurt(1, block.FireDamageSource{})
+	}
 }

--- a/server/entity/immunity.go
+++ b/server/entity/immunity.go
@@ -1,0 +1,26 @@
+package entity
+
+import "time"
+
+// AttackImmunity keeps track of the brief invulnerability an entity has after taking damage. While a window
+// is active, damage up to the amount that armed it is absorbed entirely and only the excess of a stronger
+// hit is dealt, as in vanilla. The zero value is an AttackImmunity without an active window.
+type AttackImmunity struct {
+	until time.Time
+	last  float64
+}
+
+// Reduce filters damage through the immunity window. If the window is active, the damage is reduced by the
+// amount that armed it, and immune is true. Callers deal the returned damage only if it is positive.
+func (a *AttackImmunity) Reduce(damage float64) (left float64, immune bool) {
+	if !time.Now().Before(a.until) {
+		return damage, false
+	}
+	return damage - a.last, true
+}
+
+// Arm starts a new immunity window with the duration passed, during which damage up to the damage value
+// passed is absorbed.
+func (a *AttackImmunity) Arm(d time.Duration, damage float64) {
+	a.until, a.last = time.Now().Add(d), damage
+}

--- a/server/entity/item.go
+++ b/server/entity/item.go
@@ -39,7 +39,7 @@ var ItemType itemType
 type itemType struct{}
 
 func (t itemType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (itemType) EncodeEntity() string   { return "minecraft:item" }

--- a/server/entity/item_behaviour.go
+++ b/server/entity/item_behaviour.go
@@ -175,9 +175,7 @@ func (i *ItemBehaviour) collect(e *Ent, collector Collector, tx *world.Tx) {
 	if n == 0 {
 		return
 	}
-	for _, viewer := range tx.Viewers(pos) {
-		viewer.ViewEntityAction(e, PickedUpAction{Collector: collector})
-	}
+	e.PlayAction(PickedUpAction{Collector: collector})
 
 	if n == i.i.Count() {
 		// The collector picked up the entire stack.

--- a/server/entity/lightning.go
+++ b/server/entity/lightning.go
@@ -68,15 +68,16 @@ func (s *lightningState) tick(e *Ent, tx *world.Tx) {
 func (s *lightningState) dealDamage(e *Ent, tx *world.Tx) {
 	pos := e.Position()
 	bb := e.H().Type().BBox(e).GrowVec3(mgl64.Vec3{3, 6, 3}).Translate(pos.Add(mgl64.Vec3{0, 3}))
-	for e := range tx.EntitiesWithin(bb) {
-		// Only damage entities that weren't already dead.
-		if l, ok := e.(Living); ok && l.Health() > 0 {
-			if s.Damage > 0 {
-				l.Hurt(s.Damage, LightningDamageSource{})
-			}
-			if f, ok := e.(Flammable); ok && f.OnFireDuration() < s.EntityFireDuration {
-				f.SetOnFire(s.EntityFireDuration)
-			}
+	for e := range filterDamageable(tx.EntitiesWithin(bb)) {
+		// Only strike entities that weren't already dead.
+		if l, ok := e.(Living); ok && l.Health() <= 0 {
+			continue
+		}
+		if s.Damage > 0 {
+			HurtEntity(e, s.Damage, LightningDamageSource{})
+		}
+		if f, ok := e.(Flammable); ok && f.OnFireDuration() < s.EntityFireDuration {
+			f.SetOnFire(s.EntityFireDuration)
 		}
 	}
 }

--- a/server/entity/lightning.go
+++ b/server/entity/lightning.go
@@ -115,7 +115,7 @@ var LightningType lightningType
 type lightningType struct{}
 
 func (t lightningType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 func (t lightningType) DecodeNBT(_ map[string]any, data *world.EntityData) {
 	data.Data = lightningConf.New()

--- a/server/entity/lingering_potion.go
+++ b/server/entity/lingering_potion.go
@@ -29,7 +29,7 @@ var LingeringPotionType lingeringPotionType
 type lingeringPotionType struct{}
 
 func (t lingeringPotionType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (lingeringPotionType) EncodeEntity() string {

--- a/server/entity/living.go
+++ b/server/entity/living.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"iter"
+	"math"
 
 	"github.com/df-mc/dragonfly/server/entity/effect"
 	"github.com/df-mc/dragonfly/server/world"
@@ -78,6 +79,12 @@ func KnockBackVector(pos, src mgl64.Vec3, force, height float64) mgl64.Vec3 {
 	}
 	velocity[1] = height
 	return velocity
+}
+
+// ExplosionDamage returns the damage an explosion of the size passed deals to an entity exposed to it with
+// the impact passed, following the vanilla formula.
+func ExplosionDamage(size, impact float64) float64 {
+	return math.Floor((impact*impact+impact)*3.5*size*2 + 1)
 }
 
 // filterLiving filters an entity sequence down to the entities that implement Living.

--- a/server/entity/living.go
+++ b/server/entity/living.go
@@ -6,10 +6,9 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
-// Living represents an entity that is alive and that has health. It is able to take damage and will die upon
-// taking fatal damage.
-type Living interface {
-	world.Entity
+// Damageable represents an entity that has health and may be damaged and healed. Code that deals or restores
+// damage should generally depend on Damageable rather than on the full Living interface.
+type Damageable interface {
 	// Health returns the health of the entity.
 	Health() float64
 	// MaxHealth returns the maximum health of the entity.
@@ -22,23 +21,19 @@ type Living interface {
 	// Hurt hurts the entity for a given amount of damage. The source passed represents the cause of the
 	// damage, for example AttackDamageSource if the entity is attacked by another entity.
 	// If the final damage exceeds the health that the entity currently has, the entity is killed.
-	// Hurt returns the final amount of damage dealt to the Living entity and returns whether the Living entity
-	// was vulnerable to the damage at all.
+	// Hurt returns the final amount of damage dealt to the entity and returns whether the entity was
+	// vulnerable to the damage at all.
 	Hurt(damage float64, src world.DamageSource) (n float64, vulnerable bool)
 	// Heal heals the entity for a given amount of health. The source passed represents the cause of the
 	// healing, for example FoodHealingSource if the entity healed by having a full food bar. If the health
 	// added to the original health exceeds the entity's max health, Heal may not add the full amount, Heal
 	// returns the amount of health regenerated.
 	Heal(health float64, src world.HealingSource) float64
-	// KnockBack knocks the entity back with a given force and height. A source is passed which indicates the
-	// source of the velocity, typically the position of an attacking entity. The source is used to calculate
-	// the direction which the entity should be knocked back in.
-	KnockBack(src mgl64.Vec3, force, height float64)
-	// Velocity returns the players current velocity.
-	Velocity() mgl64.Vec3
-	// SetVelocity updates the entity's velocity.
-	SetVelocity(velocity mgl64.Vec3)
-	// AddEffect adds an entity.Effect to the entity. If the effect is instant, it is applied to the entity
+}
+
+// EffectBearer represents an entity that may carry potion effects.
+type EffectBearer interface {
+	// AddEffect adds an effect.Effect to the entity. If the effect is instant, it is applied to the entity
 	// immediately. If not, the effect is applied to the entity every time the Tick method is called.
 	// AddEffect will overwrite any effects present if the level of the effect is higher than the existing one, or
 	// if the effects' levels are equal and the new effect has a longer duration.
@@ -48,6 +43,22 @@ type Living interface {
 	// Effects returns any effect currently applied to the entity. The returned effects are guaranteed not to have
 	// expired when returned.
 	Effects() []effect.Effect
+}
+
+// Living represents an entity that is alive and that has health. It is able to take damage and will die upon
+// taking fatal damage.
+type Living interface {
+	world.Entity
+	Damageable
+	EffectBearer
+	// KnockBack knocks the entity back with a given force and height. A source is passed which indicates the
+	// source of the velocity, typically the position of an attacking entity. The source is used to calculate
+	// the direction which the entity should be knocked back in.
+	KnockBack(src mgl64.Vec3, force, height float64)
+	// Velocity returns the entity's current velocity.
+	Velocity() mgl64.Vec3
+	// SetVelocity updates the entity's velocity.
+	SetVelocity(velocity mgl64.Vec3)
 	// Speed returns the current speed of the living entity. The default value is different for each entity.
 	Speed() float64
 	// SetSpeed sets the speed of an entity to a new value.

--- a/server/entity/living.go
+++ b/server/entity/living.go
@@ -1,6 +1,8 @@
 package entity
 
 import (
+	"iter"
+
 	"github.com/df-mc/dragonfly/server/entity/effect"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
@@ -76,4 +78,18 @@ func KnockBackVector(pos, src mgl64.Vec3, force, height float64) mgl64.Vec3 {
 	}
 	velocity[1] = height
 	return velocity
+}
+
+// filterLiving filters an entity sequence down to the entities that implement Living.
+func filterLiving(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
+	return func(yield func(world.Entity) bool) {
+		for e := range seq {
+			if _, living := e.(Living); !living {
+				continue
+			}
+			if !yield(e) {
+				return
+			}
+		}
+	}
 }

--- a/server/entity/living.go
+++ b/server/entity/living.go
@@ -2,10 +2,8 @@ package entity
 
 import (
 	"iter"
-	"math"
 
 	"github.com/df-mc/dragonfly/server/entity/effect"
-	"github.com/df-mc/dragonfly/server/item/inventory"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
 )
@@ -69,25 +67,6 @@ type Living interface {
 	SetSpeed(float64)
 }
 
-// KnockBackVector returns the velocity that knocks back an entity at pos away from src with the force and
-// height passed.
-func KnockBackVector(pos, src mgl64.Vec3, force, height float64) mgl64.Vec3 {
-	velocity := pos.Sub(src)
-	velocity[1] = 0
-
-	if velocity.Len() != 0 {
-		velocity = velocity.Normalize().Mul(force)
-	}
-	velocity[1] = height
-	return velocity
-}
-
-// ExplosionDamage returns the damage an explosion of the size passed deals to an entity exposed to it with
-// the impact passed, following the vanilla formula.
-func ExplosionDamage(size, impact float64) float64 {
-	return math.Floor((impact*impact+impact)*3.5*size*2 + 1)
-}
-
 // filterLiving filters an entity sequence down to the entities that implement Living.
 func filterLiving(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
 	return func(yield func(world.Entity) bool) {
@@ -100,15 +79,4 @@ func filterLiving(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
 			}
 		}
 	}
-}
-
-// FinalDamage returns the damage dealt to an entity after the armour worn and an active resistance effect
-// reduced the damage passed.
-func FinalDamage(dmg float64, src world.DamageSource, armour *inventory.Armour, effects *EffectManager) float64 {
-	dmg = max(dmg, 0)
-	dmg -= armour.DamageReduction(dmg, src)
-	if res, ok := effects.Effect(effect.Resistance); ok {
-		dmg *= effect.Resistance.Multiplier(src, res.Level())
-	}
-	return dmg
 }

--- a/server/entity/living.go
+++ b/server/entity/living.go
@@ -64,3 +64,16 @@ type Living interface {
 	// SetSpeed sets the speed of an entity to a new value.
 	SetSpeed(float64)
 }
+
+// KnockBackVector returns the velocity that knocks back an entity at pos away from src with the force and
+// height passed.
+func KnockBackVector(pos, src mgl64.Vec3, force, height float64) mgl64.Vec3 {
+	velocity := pos.Sub(src)
+	velocity[1] = 0
+
+	if velocity.Len() != 0 {
+		velocity = velocity.Normalize().Mul(force)
+	}
+	velocity[1] = height
+	return velocity
+}

--- a/server/entity/living.go
+++ b/server/entity/living.go
@@ -5,6 +5,7 @@ import (
 	"math"
 
 	"github.com/df-mc/dragonfly/server/entity/effect"
+	"github.com/df-mc/dragonfly/server/item/inventory"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
 )
@@ -99,4 +100,15 @@ func filterLiving(seq iter.Seq[world.Entity]) iter.Seq[world.Entity] {
 			}
 		}
 	}
+}
+
+// FinalDamage returns the damage dealt to an entity after the armour worn and an active resistance effect
+// reduced the damage passed.
+func FinalDamage(dmg float64, src world.DamageSource, armour *inventory.Armour, effects *EffectManager) float64 {
+	dmg = max(dmg, 0)
+	dmg -= armour.DamageReduction(dmg, src)
+	if res, ok := effects.Effect(effect.Resistance); ok {
+		dmg *= effect.Resistance.Multiplier(src, res.Level())
+	}
+	return dmg
 }

--- a/server/entity/living_ent.go
+++ b/server/entity/living_ent.go
@@ -1,0 +1,479 @@
+package entity
+
+import (
+	"math"
+	"time"
+
+	"github.com/df-mc/dragonfly/server/block"
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/entity/effect"
+	"github.com/df-mc/dragonfly/server/item"
+	"github.com/df-mc/dragonfly/server/item/enchantment"
+	"github.com/df-mc/dragonfly/server/item/inventory"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/df-mc/dragonfly/server/world/sound"
+	"github.com/go-gl/mathgl/mgl64"
+)
+
+// LivingBehaviour is a Behaviour for entities that are alive. The LivingState it returns holds the state
+// that a LivingEnt exposes through the Living interface. Because an entity is reopened in every
+// transaction, this state must be part of the Behaviour rather than the entity itself.
+type LivingBehaviour interface {
+	Behaviour
+	// LivingState returns the state of the living entity. It must return the same LivingState for the
+	// lifetime of the entity.
+	LivingState() *LivingState
+}
+
+// LivingHurtHandler may be implemented by a LivingBehaviour to handle damage dealt to its entity. It is
+// called before any other processing of the damage, so it also runs while the entity is immune to attacks.
+type LivingHurtHandler interface {
+	// HandleHurt handles damage about to be dealt to the entity. The damage may be changed through the
+	// pointer passed. If true is returned, the damage is cancelled entirely.
+	HandleHurt(e *LivingEnt, damage *float64, src world.DamageSource) bool
+}
+
+// LivingDeathHandler may be implemented by a LivingBehaviour to react to the death of its entity. It is
+// called on the tick after the fatal damage, so a *world.Tx is available.
+type LivingDeathHandler interface {
+	// HandleDeath handles the death of the entity, before it is closed and removed from the world.
+	HandleDeath(e *LivingEnt, tx *world.Tx, src world.DamageSource)
+}
+
+// LivingState holds the state of a living entity that persists across transactions. A LivingBehaviour
+// creates one using NewLivingState and returns it from its LivingState method.
+type LivingState struct {
+	// Health manages the entity's current and maximum health.
+	Health *HealthManager
+	// Effects manages the effects active on the entity. They are ticked by LivingEnt.Tick.
+	Effects *EffectManager
+	// Immunity tracks the invulnerability window the entity has after being hurt.
+	Immunity AttackImmunity
+	// HurtImmunity is the duration of the immunity window armed when the entity is hurt.
+	HurtImmunity time.Duration
+	// Air tracks the air the entity has left while submerged.
+	Air *AirSupply
+	// Armour holds the armour worn by the entity. Worn items reduce incoming damage, resist knock back,
+	// retaliate with thorns and lose durability exactly as they do for players, and are shown to viewers.
+	Armour *inventory.Armour
+	// MainHand and OffHand are the items held by the entity, shown to viewers. Change them through
+	// LivingEnt.SetHeldItems so viewers see the change.
+	MainHand, OffHand item.Stack
+	// Speed is the movement speed of the entity.
+	Speed float64
+	// KnockBackResistance is the fraction, between 0 and 1, by which knock back on the entity is reduced.
+	// Resistance from worn armour is added on top of it.
+	KnockBackResistance float64
+	// FireImmune makes the entity immune to fire damage and prevents it from being set on fire.
+	FireImmune bool
+	// Scale is the size modifier of the entity, with 1 being the regular size.
+	Scale float64
+	// Baby marks the entity as a baby to viewers.
+	Baby bool
+	// Variant and MarkVariant select the visual variant of the entity for viewers.
+	Variant, MarkVariant int32
+	// FallDistance is the distance the entity has been falling for. It is updated through
+	// LivingEnt.UpdateFallState and converted to fall damage upon landing.
+	FallDistance float64
+
+	absorption float64
+	dead       bool
+	deathSrc   world.DamageSource
+}
+
+// NewLivingState returns a LivingState with the health passed and vanilla defaults for the remaining
+// state: a speed of 0.1, half a second of hurt immunity, 15 seconds of air, a scale of 1 and empty armour
+// and hands.
+func NewLivingState(health float64) *LivingState {
+	return &LivingState{
+		Health:       NewHealthManager(health, health),
+		Effects:      NewEffectManager(),
+		Air:          NewAirSupply(0),
+		Armour:       inventory.NewArmour(nil),
+		Speed:        0.1,
+		Scale:        1,
+		HurtImmunity: time.Second / 2,
+	}
+}
+
+// Dead checks if the living entity has taken fatal damage.
+func (s *LivingState) Dead() bool {
+	return s.dead
+}
+
+// SetAbsorption sets the absorption health of the living state. The value is clamped to zero or above.
+func (s *LivingState) SetAbsorption(health float64) {
+	s.absorption = max(health, 0)
+}
+
+// LivingEnt is an Ent that is alive. It implements Living on top of the LivingState of its Behaviour, which
+// makes the entity part of everything gated on Living. Entity implementations based on a LivingBehaviour
+// return a LivingEnt from the Open method of their world.EntityType by calling OpenLiving.
+type LivingEnt struct {
+	*Ent
+}
+
+var _ Living = (*LivingEnt)(nil)
+
+// OpenLiving converts a world.EntityHandle to a LivingEnt in a world.Tx. It panics if the Behaviour of the
+// entity does not implement LivingBehaviour.
+func OpenLiving(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) *LivingEnt {
+	e := &LivingEnt{Ent: Open(tx, handle, data)}
+	_ = e.behaviour()
+	return e
+}
+
+// behaviour returns the Behaviour of the entity as a LivingBehaviour.
+func (e *LivingEnt) behaviour() LivingBehaviour {
+	return e.Behaviour().(LivingBehaviour)
+}
+
+// state returns the LivingState of the entity's Behaviour.
+func (e *LivingEnt) state() *LivingState {
+	return e.behaviour().LivingState()
+}
+
+// Health returns the current health of the entity.
+func (e *LivingEnt) Health() float64 {
+	return e.state().Health.Health()
+}
+
+// MaxHealth returns the maximum health of the entity.
+func (e *LivingEnt) MaxHealth() float64 {
+	return e.state().Health.MaxHealth()
+}
+
+// SetMaxHealth changes the maximum health of the entity to the value passed.
+func (e *LivingEnt) SetMaxHealth(v float64) {
+	e.state().Health.SetMaxHealth(v)
+}
+
+// Dead checks if the entity has taken fatal damage.
+func (e *LivingEnt) Dead() bool {
+	return e.state().Dead()
+}
+
+// Hurt hurts the entity for a given amount of damage. The damage is first passed to the Behaviour's
+// HandleHurt, if implemented, which may change or cancel it. Worn armour and an active resistance effect
+// then reduce it, and within the immunity window of an earlier hit only the excess over the damage that
+// armed the window is dealt. Absorption health is consumed before regular health. If the damage is fatal,
+// the entity is killed on its next tick, so that drops spawned by the Behaviour's HandleDeath have a
+// transaction to be added in.
+func (e *LivingEnt) Hurt(damage float64, src world.DamageSource) (float64, bool) {
+	s := e.state()
+	if damage < 0 || s.dead {
+		return 0, false
+	}
+	if src.Fire() {
+		if _, ok := s.Effects.Effect(effect.FireResistance); ok || s.FireImmune {
+			return 0, false
+		}
+	}
+	if h, ok := e.Behaviour().(LivingHurtHandler); ok && h.HandleHurt(e, &damage, src) {
+		return 0, false
+	}
+	if src.ReducedByArmour() {
+		damage -= s.Armour.DamageReduction(damage, src)
+	}
+	if res, ok := s.Effects.Effect(effect.Resistance); ok && src.ReducedByResistance() {
+		damage *= effect.Resistance.Multiplier(src, res.Level())
+	}
+	damageLeft, immune := s.Immunity.Reduce(damage)
+	if immune && damageLeft <= 0 {
+		return 0, false
+	}
+	s.Immunity.Arm(s.HurtImmunity, damage)
+
+	if a := s.absorption; a > 0 {
+		s.SetAbsorption(a - damageLeft)
+		damageLeft = max(0, damageLeft-a)
+		if _, ok := s.Effects.Effect(effect.Absorption); ok && s.absorption <= 0 {
+			e.RemoveEffect(effect.Absorption)
+		}
+	}
+
+	s.Health.AddHealth(-damageLeft)
+	e.PlayAction(HurtAction{})
+
+	if src.ReducedByArmour() {
+		s.Armour.Damage(damage, e.damageItem)
+
+		var origin world.Entity
+		if a, ok := src.(AttackDamageSource); ok {
+			origin = a.Attacker
+		} else if p, ok := src.(ProjectileDamageSource); ok {
+			origin = p.Owner
+		}
+		if l, ok := origin.(Living); ok {
+			if thorns := s.Armour.ThornsDamage(e.damageItem); thorns > 0 {
+				l.Hurt(thorns, enchantment.ThornsDamageSource{Owner: e})
+			}
+		}
+	}
+
+	if s.Health.Health() <= 0 {
+		s.dead, s.deathSrc = true, src
+	}
+	return damageLeft, true
+}
+
+// Heal heals the entity for a given amount of health, up to its maximum health, and returns the amount of
+// health that was regenerated. A dead entity is not healed.
+func (e *LivingEnt) Heal(health float64, _ world.HealingSource) float64 {
+	s := e.state()
+	if s.dead || health <= 0 {
+		return 0
+	}
+	before := s.Health.Health()
+	s.Health.AddHealth(health)
+	return s.Health.Health() - before
+}
+
+// KnockBack knocks the entity back away from the source position passed. The knock back resistance of the
+// entity's LivingState and its worn armour is applied. A dead entity is not knocked back.
+func (e *LivingEnt) KnockBack(src mgl64.Vec3, force, height float64) {
+	if e.state().dead {
+		return
+	}
+	velocity := KnockBackVector(e.Position(), src, force, height)
+	e.SetVelocity(velocity.Mul(1 - e.knockBackResistance()))
+}
+
+// knockBackResistance returns the total knock back resistance of the entity, from its LivingState and its
+// worn armour, capped at 1.
+func (e *LivingEnt) knockBackResistance() float64 {
+	s := e.state()
+	return min(1, s.KnockBackResistance+s.Armour.KnockBackResistance())
+}
+
+// Explode hurts the entity with vanilla explosion damage and knocks it back away from the explosion. It
+// takes the place of the Behaviour's ExplodableBehaviour hook, which is not called for living entities.
+func (e *LivingEnt) Explode(src world.ExplosionSource, impact float64) {
+	diff := e.Position().Sub(src.Position())
+	e.Hurt(ExplosionDamage(src.Size(), impact), ExplosionDamageSource{Source: src})
+
+	height := 0.0
+	if l := diff.Len(); l != 0 {
+		height = diff[1] / l * impact
+	}
+	// The knock back is applied even to an entity killed by the explosion, so its body is still launched.
+	velocity := KnockBackVector(e.Position(), src.Position(), impact, height)
+	e.SetVelocity(velocity.Mul(1 - e.knockBackResistance()))
+}
+
+// SetOnFire sets the entity on fire for the duration passed. Fire protection on worn armour reduces the
+// duration, and a fire-immune entity is never set on fire.
+func (e *LivingEnt) SetOnFire(duration time.Duration) {
+	s := e.state()
+	if s.FireImmune {
+		return
+	}
+	ticks := int64(duration.Seconds() * 20)
+	if level := s.Armour.HighestEnchantmentLevel(enchantment.FireProtection); level > 0 {
+		ticks -= int64(math.Floor(float64(ticks) * float64(level) * 0.15))
+	}
+	e.Ent.SetOnFire(time.Duration(ticks) * time.Second / 20)
+}
+
+// AddEffect adds an effect to the entity. If the effect is instant, it is applied immediately. If not, it is
+// applied every tick until it expires.
+func (e *LivingEnt) AddEffect(eff effect.Effect) {
+	e.state().Effects.Add(eff, e)
+}
+
+// RemoveEffect removes any effect of the type passed that is active on the entity.
+func (e *LivingEnt) RemoveEffect(t effect.Type) {
+	e.state().Effects.Remove(t, e)
+}
+
+// Effects returns the effects currently active on the entity.
+func (e *LivingEnt) Effects() []effect.Effect {
+	return e.state().Effects.Effects()
+}
+
+// Speed returns the current speed of the entity.
+func (e *LivingEnt) Speed() float64 {
+	return e.state().Speed
+}
+
+// SetSpeed sets the speed of the entity to a new value.
+func (e *LivingEnt) SetSpeed(v float64) {
+	e.state().Speed = v
+}
+
+// Absorption returns the absorption health of the entity.
+func (e *LivingEnt) Absorption() float64 {
+	return e.state().absorption
+}
+
+// SetAbsorption sets the absorption health of the entity. The value is clamped to zero or above.
+func (e *LivingEnt) SetAbsorption(health float64) {
+	e.state().SetAbsorption(health)
+}
+
+// Armour returns the armour worn by the entity. After changing its contents, UpdateArmour shows the change
+// to viewers.
+func (e *LivingEnt) Armour() *inventory.Armour {
+	return e.state().Armour
+}
+
+// UpdateArmour shows the entity's current armour to viewers.
+func (e *LivingEnt) UpdateArmour() {
+	for _, v := range e.tx.Viewers(e.data.Pos) {
+		v.ViewEntityArmour(e)
+	}
+}
+
+// HeldItems returns the items currently held by the entity in its main hand and off hand.
+func (e *LivingEnt) HeldItems() (mainHand, offHand item.Stack) {
+	s := e.state()
+	return s.MainHand, s.OffHand
+}
+
+// SetHeldItems changes the items held by the entity and shows the change to viewers.
+func (e *LivingEnt) SetHeldItems(mainHand, offHand item.Stack) {
+	s := e.state()
+	s.MainHand, s.OffHand = mainHand, offHand
+	for _, v := range e.tx.Viewers(e.data.Pos) {
+		v.ViewEntityItems(e)
+	}
+}
+
+// Scale returns the size modifier of the entity.
+func (e *LivingEnt) Scale() float64 {
+	return e.state().Scale
+}
+
+// SetScale changes the size modifier of the entity and shows the change to viewers.
+func (e *LivingEnt) SetScale(scale float64) {
+	e.state().Scale = scale
+	e.UpdateState()
+}
+
+// Baby checks if the entity is marked as a baby.
+func (e *LivingEnt) Baby() bool {
+	return e.state().Baby
+}
+
+// Variant returns the visual variant of the entity.
+func (e *LivingEnt) Variant() int32 {
+	return e.state().Variant
+}
+
+// MarkVariant returns the visual mark variant of the entity.
+func (e *LivingEnt) MarkVariant() int32 {
+	return e.state().MarkVariant
+}
+
+// Breathing checks if the entity is currently able to breathe.
+func (e *LivingEnt) Breathing() bool {
+	return e.state().Air.Breathing()
+}
+
+// AirSupply returns the air the entity has left.
+func (e *LivingEnt) AirSupply() time.Duration {
+	return e.state().Air.Supply()
+}
+
+// MaxAirSupply returns the maximum air supply of the entity.
+func (e *LivingEnt) MaxAirSupply() time.Duration {
+	return e.state().Air.Max()
+}
+
+// FallDistance returns the distance the entity has been falling for.
+func (e *LivingEnt) FallDistance() float64 {
+	return e.state().FallDistance
+}
+
+// ResetFallDistance resets the distance the entity has been falling for, cancelling any pending fall
+// damage.
+func (e *LivingEnt) ResetFallDistance() {
+	e.state().FallDistance = 0
+}
+
+// UpdateFallState progresses the fall state of the entity with the vertical movement of one tick. A
+// Behaviour running its own physics calls it every tick: while the entity falls, the fall distance grows,
+// and upon landing, the block landed on may soften the fall before the remaining distance, reduced by any
+// jump boost effect, is dealt as fall damage.
+func (e *LivingEnt) UpdateFallState(deltaY float64, onGround bool) {
+	s := e.state()
+	if onGround {
+		if s.FallDistance > 0 {
+			distance := s.FallDistance
+			s.FallDistance = 0
+			CheckEntityLanders(e.tx, e, e.H().Type().BBox(e).Translate(e.data.Pos), &distance)
+
+			if boost, ok := s.Effects.Effect(effect.JumpBoost); ok {
+				distance -= float64(boost.Level())
+			}
+			if damage := distance - 3; damage > 0 {
+				e.Hurt(damage, FallDamageSource{})
+			}
+		}
+		return
+	}
+	if deltaY < 0 {
+		s.FallDistance -= deltaY
+	}
+}
+
+// damageItem applies durability damage to an item worn by the entity, respecting its unbreaking
+// enchantment and breaking it once its durability runs out.
+func (e *LivingEnt) damageItem(s item.Stack, d int) item.Stack {
+	if d == 0 || s.MaxDurability() == -1 {
+		return s
+	}
+	if ench, ok := s.Enchantment(enchantment.Unbreaking); ok {
+		d = enchantment.Unbreaking.Reduce(s.Item(), ench.Level(), d)
+	}
+	if s = s.Damage(d); s.Empty() {
+		e.tx.PlaySound(e.data.Pos, sound.ItemBreak{})
+	}
+	return s
+}
+
+// Tick ticks the entity. A dead entity plays its death animation, has the Behaviour's HandleDeath called if
+// implemented and is closed. A living entity is damaged by the void, fire, suffocation and drowning where
+// applicable, dispatches the contact hooks of the blocks it is inside of, and has its effects ticked before
+// it is ticked as an Ent as usual.
+func (e *LivingEnt) Tick(tx *world.Tx, current int64) {
+	s := e.state()
+	if s.dead {
+		// The death animation and removal go out in the same tick: clients play the animation on the
+		// removed entity themselves.
+		e.PlayAction(DeathAction{})
+		if h, ok := e.Behaviour().(LivingDeathHandler); ok {
+			h.HandleDeath(e, tx, s.deathSrc)
+		}
+		_ = e.Close()
+		return
+	}
+	if e.data.Pos[1] < float64(tx.Range()[0]) && current%10 == 0 {
+		e.Hurt(4, VoidDamageSource{})
+	}
+	if e.OnFireDuration() > 0 {
+		if tx.RainingAt(cube.PosFromVec3(e.data.Pos)) {
+			e.Extinguish()
+		} else if current%20 == 0 {
+			e.Hurt(1, block.FireDamageSource{})
+		}
+	}
+	if current%10 == 0 && InsideOfSolid(e, tx) {
+		e.Hurt(1, SuffocationDamageSource{})
+	}
+
+	_, waterBreathing := s.Effects.Effect(effect.WaterBreathing)
+	_, conduitPower := s.Effects.Effect(effect.ConduitPower)
+	drowned, changed := s.Air.Tick(waterBreathing || conduitPower || !Submerged(e, tx), s.Armour.Helmet())
+	if drowned {
+		e.Hurt(2, DrowningDamageSource{})
+	}
+	if changed {
+		e.updateState()
+	}
+
+	CheckEntityInsiders(tx, e, e.H().Type().BBox(e).Translate(e.data.Pos))
+
+	s.Effects.Tick(e, tx)
+	e.Ent.Tick(tx, current)
+}

--- a/server/entity/living_ent.go
+++ b/server/entity/living_ent.go
@@ -167,6 +167,10 @@ func (e *LivingEnt) Hurt(damage float64, src world.DamageSource) (float64, bool)
 			return 0, false
 		}
 	}
+	ctx := e.tx.Event()
+	if e.tx.World().Handler().HandleEntityHurt(ctx, e, &damage, src); ctx.Cancelled() {
+		return 0, false
+	}
 	if h, ok := e.Behaviour().(LivingHurtHandler); ok && h.HandleHurt(e, &damage, src) {
 		return 0, false
 	}

--- a/server/entity/living_ent.go
+++ b/server/entity/living_ent.go
@@ -397,23 +397,17 @@ func (e *LivingEnt) ResetFallDistance() {
 // jump boost effect, is dealt as fall damage.
 func (e *LivingEnt) UpdateFallState(deltaY float64, onGround bool) {
 	s := e.state()
-	if onGround {
-		if s.FallDistance > 0 {
-			distance := s.FallDistance
-			s.FallDistance = 0
-			CheckEntityLanders(e.tx, e, e.H().Type().BBox(e).Translate(e.data.Pos), &distance)
-
-			if boost, ok := s.Effects.Effect(effect.JumpBoost); ok {
-				distance -= float64(boost.Level())
-			}
-			if damage := distance - 3; damage > 0 {
-				e.Hurt(damage, FallDamageSource{})
-			}
-		}
-		return
-	}
-	if deltaY < 0 {
+	switch {
+	case onGround:
 		s.FallDistance -= deltaY
+		if s.FallDistance > 3 {
+			Fall(e, e.tx, s.Effects, s.FallDistance)
+		}
+		s.FallDistance = 0
+	case deltaY < 0 && deltaY < s.FallDistance:
+		s.FallDistance -= deltaY
+	default:
+		s.FallDistance = 0
 	}
 }
 

--- a/server/entity/living_ent.go
+++ b/server/entity/living_ent.go
@@ -172,12 +172,7 @@ func (e *LivingEnt) Hurt(damage float64, src world.DamageSource) (float64, bool)
 	if h, ok := e.Behaviour().(LivingHurtHandler); ok && h.HandleHurt(e, &damage, src) {
 		return 0, false
 	}
-	if src.ReducedByArmour() {
-		damage -= s.Armour.DamageReduction(damage, src)
-	}
-	if res, ok := s.Effects.Effect(effect.Resistance); ok && src.ReducedByResistance() {
-		damage *= effect.Resistance.Multiplier(src, res.Level())
-	}
+	damage = FinalDamage(damage, src, s.Armour, s.Effects)
 	damageLeft, immune := s.Immunity.Reduce(damage)
 	if immune && damageLeft <= 0 {
 		return 0, false

--- a/server/entity/living_ent.go
+++ b/server/entity/living_ent.go
@@ -4,8 +4,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/df-mc/dragonfly/server/block"
-	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/entity/effect"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/item/enchantment"
@@ -440,13 +438,7 @@ func (e *LivingEnt) Tick(tx *world.Tx, current int64) {
 	if e.data.Pos[1] < float64(tx.Range()[0]) && current%10 == 0 {
 		e.Hurt(4, VoidDamageSource{})
 	}
-	if e.OnFireDuration() > 0 {
-		if tx.RainingAt(cube.PosFromVec3(e.data.Pos)) {
-			e.Extinguish()
-		} else if current%20 == 0 {
-			e.Hurt(1, block.FireDamageSource{})
-		}
-	}
+	TickOnFire(e, tx)
 	if current%10 == 0 && InsideOfSolid(e, tx) {
 		e.Hurt(1, SuffocationDamageSource{})
 	}

--- a/server/entity/movement.go
+++ b/server/entity/movement.go
@@ -23,18 +23,32 @@ type Movement struct {
 	v                    []world.Viewer
 	e                    world.Entity
 	pos, vel, dpos, dvel mgl64.Vec3
-	rot                  cube.Rotation
+	rot, drot            cube.Rotation
 	onGround             bool
 }
 
-// Send sends the Movement to any viewers watching the entity at the time of the movement. If the position/velocity
-// changes were negligible, nothing is sent.
+// NewMovement creates a Movement that moves an Ent to the position, velocity and rotation passed, updating the
+// entity's data accordingly. Behaviours that run their own physics return it from their Tick method to have the
+// movement sent to viewers.
+func NewMovement(e *Ent, pos, vel mgl64.Vec3, rot cube.Rotation, onGround bool) *Movement {
+	prevPos, prevVel, prevRot := e.data.Pos, e.data.Vel, e.data.Rot
+	e.data.Pos, e.data.Vel, e.data.Rot = pos, vel, rot
+	return &Movement{v: e.tx.Viewers(prevPos), e: e,
+		pos: pos, vel: vel, dpos: pos.Sub(prevPos), dvel: vel.Sub(prevVel),
+		rot: rot, drot: cube.Rotation{rot[0] - prevRot[0], rot[1] - prevRot[1]},
+		onGround: onGround,
+	}
+}
+
+// Send sends the Movement to any viewers watching the entity at the time of the movement. If the position, rotation
+// and velocity changes were negligible, nothing is sent.
 func (m *Movement) Send() {
 	posChanged := !m.dpos.ApproxEqualThreshold(zeroVec3, epsilon)
+	rotChanged := math.Abs(m.drot[0]) > epsilon || math.Abs(m.drot[1]) > epsilon
 	velChanged := !m.dvel.ApproxEqualThreshold(zeroVec3, epsilon)
 
 	for _, v := range m.v {
-		if posChanged {
+		if posChanged || rotChanged {
 			v.ViewEntityMovement(m.e, m.pos, m.rot, m.onGround)
 		}
 		if velChanged {

--- a/server/entity/movement.go
+++ b/server/entity/movement.go
@@ -186,11 +186,11 @@ func (c *MovementComputer) CheckCollision(tx *world.Tx, e world.Entity, pos, vel
 // what blocks need to have their BBox returned.
 func blockBBoxsAround(tx *world.Tx, box cube.BBox) []cube.BBox {
 	grown := box.Grow(0.25)
-	min, max := grown.Min(), grown.Max()
-	minX, minY, minZ := int(math.Floor(min[0])), int(math.Floor(min[1])), int(math.Floor(min[2]))
+	low, high := grown.Min(), grown.Max()
+	minX, minY, minZ := int(math.Floor(low[0])), int(math.Floor(low[1])), int(math.Floor(low[2]))
 	// The maximum bounds are exclusive: A block starting exactly at the box's
 	// maximum cannot collide with it.
-	maxX, maxY, maxZ := int(math.Ceil(max[0])), int(math.Ceil(max[1])), int(math.Ceil(max[2]))
+	maxX, maxY, maxZ := int(math.Ceil(high[0])), int(math.Ceil(high[1])), int(math.Ceil(high[2]))
 
 	// A prediction of one BBox per block, plus an additional 2, in case. Allocate
 	// it lazily so that entities moving through air do not allocate an empty slice

--- a/server/entity/passive.go
+++ b/server/entity/passive.go
@@ -95,9 +95,7 @@ func (p *PassiveBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 	}
 
 	if p.Fuse()%(time.Second/4) == 0 {
-		for _, v := range tx.Viewers(m.pos) {
-			v.ViewEntityState(e)
-		}
+		e.UpdateState()
 	}
 
 	if e.Age() > p.conf.ExistenceDuration {

--- a/server/entity/passive.go
+++ b/server/entity/passive.go
@@ -86,7 +86,7 @@ func (p *PassiveBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 
 	m := p.mc.TickMovement(e, e.data.Pos, e.data.Vel, e.data.Rot, tx)
 	e.data.Pos, e.data.Vel = m.pos, m.vel
-	p.fallDistance = math.Max(p.fallDistance-m.dpos[1], 0)
+	p.fallDistance = max(p.fallDistance-m.dpos[1], 0)
 
 	p.fuse = p.conf.ExistenceDuration - e.Age()
 

--- a/server/entity/projectile.go
+++ b/server/entity/projectile.go
@@ -186,7 +186,7 @@ func (lt *ProjectileBehaviour) Tick(e *Ent, tx *world.Tx) *Movement {
 		return m
 	}
 
-	for i := 0; i < lt.conf.ParticleCount; i++ {
+	for range lt.conf.ParticleCount {
 		tx.AddParticle(result.Position(), lt.conf.Particle)
 	}
 	if lt.conf.Sound != nil {

--- a/server/entity/projectile.go
+++ b/server/entity/projectile.go
@@ -261,9 +261,7 @@ func (lt *ProjectileBehaviour) tryPickup(e *Ent, tx *world.Tx) {
 
 		// A collector was within range and able to pick up the entity.
 		lt.close = true
-		for _, viewer := range tx.Viewers(e.Position()) {
-			viewer.ViewEntityAction(e, PickedUpAction{Collector: collector})
-		}
+		e.PlayAction(PickedUpAction{Collector: collector})
 		// Only one collector may pick the projectile up: every further one would receive a copy of it.
 		return
 	}

--- a/server/entity/register.go
+++ b/server/entity/register.go
@@ -9,7 +9,7 @@ import (
 
 // DefaultRegistry is a world.EntityRegistry that registers all default entities
 // implemented by Dragonfly.
-var DefaultRegistry = conf.New([]world.EntityType{
+var DefaultRegistry = registryConf.New([]world.EntityType{
 	AreaEffectCloudType,
 	ArrowType,
 	BottleOfEnchantingType,
@@ -28,7 +28,7 @@ var DefaultRegistry = conf.New([]world.EntityType{
 	TextType,
 })
 
-var conf = world.EntityRegistryConfig{
+var registryConf = world.EntityRegistryConfig{
 	TNT:                NewTNT,
 	Egg:                NewEgg,
 	EndCrystal:         NewEndCrystal,
@@ -51,15 +51,15 @@ var conf = world.EntityRegistryConfig{
 	},
 	Arrow: func(opts world.EntitySpawnOpts, arrow world.ArrowSpawnConfig) *world.EntityHandle {
 		tip := arrow.Tip.(potion.Potion)
-		conf := arrowConf
-		conf.Damage, conf.Potion, conf.Owner = arrow.Damage, tip, arrow.Owner.H()
-		conf.KnockBackForceAddend = float64(arrow.PunchLevel) * enchantment.Punch.KnockBackMultiplier()
-		conf.DisablePickup = arrow.DisablePickup
+		arrowC := arrowConf
+		arrowC.Damage, arrowC.Potion, arrowC.Owner = arrow.Damage, tip, arrow.Owner.H()
+		arrowC.KnockBackForceAddend = float64(arrow.PunchLevel) * enchantment.Punch.KnockBackMultiplier()
+		arrowC.DisablePickup = arrow.DisablePickup
 		if arrow.ObtainArrowOnPickup {
-			conf.PickupItem = item.NewStack(item.Arrow{Tip: tip}, 1)
+			arrowC.PickupItem = item.NewStack(item.Arrow{Tip: tip}, 1)
 		}
-		conf.Critical = arrow.Critical
-		conf.PiercingLevel = arrow.PiercingLevel
-		return opts.New(ArrowType, conf)
+		arrowC.Critical = arrow.Critical
+		arrowC.PiercingLevel = arrow.PiercingLevel
+		return opts.New(ArrowType, arrowC)
 	},
 }

--- a/server/entity/snowball.go
+++ b/server/entity/snowball.go
@@ -26,7 +26,7 @@ var SnowballType snowballType
 type snowballType struct{}
 
 func (t snowballType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (snowballType) EncodeEntity() string { return "minecraft:snowball" }

--- a/server/entity/splash_potion.go
+++ b/server/entity/splash_potion.go
@@ -37,7 +37,7 @@ var SplashPotionType splashPotionType
 type splashPotionType struct{}
 
 func (t splashPotionType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (splashPotionType) EncodeEntity() string { return "minecraft:splash_potion" }

--- a/server/entity/text.go
+++ b/server/entity/text.go
@@ -19,7 +19,7 @@ var TextType textType
 type textType struct{}
 
 func (t textType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 func (textType) EncodeEntity() string        { return "dragonfly:text" }
 func (textType) BBox(world.Entity) cube.BBox { return cube.BBox{} }

--- a/server/entity/tnt.go
+++ b/server/entity/tnt.go
@@ -43,7 +43,7 @@ var TNTType tntType
 type tntType struct{}
 
 func (t tntType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (tntType) EncodeEntity() string   { return "minecraft:tnt" }

--- a/server/entity/travel.go
+++ b/server/entity/travel.go
@@ -296,11 +296,11 @@ func (t *PortalTravelComputer) finishTravel(e Traveller, pos mgl64.Vec3, source,
 // handlePortalTravel dispatches portal travel hooks to Ent behaviours and
 // non-Ent travellers that implement portalTravelHandler.
 func handlePortalTravel(e Traveller, source, destination world.Dimension) {
-	if ent, ok := e.(*Ent); ok {
-		if h, ok := ent.Behaviour().(portalTravelHandler); ok {
+	if w, ok := e.(wrappedEnt); ok {
+		if h, ok := w.Unwrap().Behaviour().(portalTravelHandler); ok {
 			h.HandlePortalTravel(source, destination)
+			return
 		}
-		return
 	}
 	if h, ok := e.(portalTravelHandler); ok {
 		h.HandlePortalTravel(source, destination)

--- a/server/entity/travel.go
+++ b/server/entity/travel.go
@@ -297,7 +297,7 @@ func (t *PortalTravelComputer) finishTravel(e Traveller, pos mgl64.Vec3, source,
 // non-Ent travellers that implement PortalTravelHandler.
 func handlePortalTravel(e Traveller, source, destination world.Dimension) {
 	if w, ok := e.(wrappedEnt); ok {
-		if h, ok := w.Unwrap().Behaviour().(PortalTravelHandler); ok {
+		if h, ok := w.Base().Behaviour().(PortalTravelHandler); ok {
 			h.HandlePortalTravel(source, destination)
 			return
 		}

--- a/server/entity/travel.go
+++ b/server/entity/travel.go
@@ -49,10 +49,10 @@ func NewPortalTravelComputer() *PortalTravelComputer {
 // Bedrock Edition searches 128 blocks in both dimensions.
 const portalSearchRadius = 128
 
-// portalTravelComputerProvider is implemented by behaviours of entities that can travel through portals.
+// PortalTravelComputerProvider is implemented by behaviours of entities that can travel through portals.
 // Behaviours without a computer never travel. This matches vanilla, where some entities, such as falling blocks,
 // cannot use portals.
-type portalTravelComputerProvider interface {
+type PortalTravelComputerProvider interface {
 	PortalTravelComputer() *PortalTravelComputer
 }
 
@@ -63,7 +63,7 @@ type Traveller interface {
 	Teleport(pos mgl64.Vec3)
 }
 
-type portalTravelHandler interface {
+type PortalTravelHandler interface {
 	HandlePortalTravel(source, destination world.Dimension)
 }
 
@@ -294,15 +294,15 @@ func (t *PortalTravelComputer) finishTravel(e Traveller, pos mgl64.Vec3, source,
 }
 
 // handlePortalTravel dispatches portal travel hooks to Ent behaviours and
-// non-Ent travellers that implement portalTravelHandler.
+// non-Ent travellers that implement PortalTravelHandler.
 func handlePortalTravel(e Traveller, source, destination world.Dimension) {
 	if w, ok := e.(wrappedEnt); ok {
-		if h, ok := w.Unwrap().Behaviour().(portalTravelHandler); ok {
+		if h, ok := w.Unwrap().Behaviour().(PortalTravelHandler); ok {
 			h.HandlePortalTravel(source, destination)
 			return
 		}
 	}
-	if h, ok := e.(portalTravelHandler); ok {
+	if h, ok := e.(PortalTravelHandler); ok {
 		h.HandlePortalTravel(source, destination)
 	}
 }

--- a/server/entity/travel_test.go
+++ b/server/entity/travel_test.go
@@ -583,7 +583,7 @@ func (b *testMoveBehaviour) Tick(e *Ent, _ *world.Tx) *Movement {
 type testMovingEntType struct{}
 
 func (testMovingEntType) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
-	return &Ent{tx: tx, handle: handle, data: data}
+	return Open(tx, handle, data)
 }
 
 func (testMovingEntType) EncodeEntity() string { return "minecraft:test_moving_ent" }

--- a/server/player/conf.go
+++ b/server/player/conf.go
@@ -80,14 +80,13 @@ func (cfg Config) Apply(data *world.EntityData) {
 		flightSpeed:         0.05,
 		verticalFlightSpeed: 1.0,
 		scale:               1.0,
-		airSupplyTicks:      conf.AirSupply,
-		maxAirSupplyTicks:   conf.MaxAirSupply,
-		breathing:           true,
+		air:                 entity.NewAirSupply(time.Duration(conf.MaxAirSupply) * time.Second / 20),
 		nameTag:             conf.Name,
 		alwaysShowNameTag:   true,
 		fireTicks:           conf.FireTicks,
 		fallDistance:        conf.FallDistance,
 	}
+	pdata.air.SetSupply(time.Duration(conf.AirSupply) * time.Second / 20)
 	playerUUID := conf.UUID
 	pdata.portalTravel = &entity.PortalTravelComputer{
 		Instantaneous: func(_, target world.Dimension) bool {

--- a/server/player/conf.go
+++ b/server/player/conf.go
@@ -83,7 +83,6 @@ func (cfg Config) Apply(data *world.EntityData) {
 		air:                 entity.NewAirSupply(time.Duration(conf.MaxAirSupply) * time.Second / 20),
 		nameTag:             conf.Name,
 		alwaysShowNameTag:   true,
-		fireTicks:           conf.FireTicks,
 		fallDistance:        conf.FallDistance,
 	}
 	pdata.air.SetSupply(time.Duration(conf.AirSupply) * time.Second / 20)
@@ -112,6 +111,7 @@ func (cfg Config) Apply(data *world.EntityData) {
 	}
 	pdata.hunger.foodLevel, pdata.hunger.foodTick, pdata.hunger.exhaustionLevel, pdata.hunger.saturationLevel = conf.Food, conf.FoodTick, conf.Exhaustion, conf.Saturation
 	pdata.experience.Add(conf.Experience)
+	data.FireDuration = time.Duration(conf.FireTicks) * time.Second / 20
 	data.Data = pdata
 }
 

--- a/server/player/context.go
+++ b/server/player/context.go
@@ -15,7 +15,7 @@ type Context struct {
 // NewEventContext returns a fresh event context for p.
 // tx and p must come from the same active owner callback.
 func NewEventContext(tx *world.Tx, p *Player) *Context {
-	if tx == nil || p == nil || p.tx != tx {
+	if tx == nil || p == nil || p.Tx() != tx {
 		panic("player: transaction and player do not belong to the same callback")
 	}
 	_ = tx.World() // Fail immediately if tx has already finished.

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -737,7 +737,12 @@ func (p *Player) Explode(src world.ExplosionSource, impact float64) {
 	explosionPos := src.Position()
 	diff := p.Position().Sub(explosionPos)
 	p.Hurt(entity.ExplosionDamage(src.Size(), impact), entity.ExplosionDamageSource{Source: src})
-	p.knockBack(explosionPos, impact, diff[1]/diff.Len()*impact)
+
+	height := 0.0
+	if l := diff.Len(); l != 0 {
+		height = diff[1] / l * impact
+	}
+	p.knockBack(explosionPos, impact, height)
 }
 
 // SetAbsorption sets the absorption health of a player. This extra health shows as golden hearts and do not
@@ -2963,29 +2968,7 @@ func (p *Player) checkBlockCollisions(vel mgl64.Vec3) {
 
 // checkEntityInsiders checks if the player is colliding with any EntityInsider blocks.
 func (p *Player) checkEntityInsiders(entityBBox cube.BBox) {
-	box := entityBBox.Grow(-0.0001)
-	low, high := cube.PosFromVec3(box.Min()), cube.PosFromVec3(box.Max())
-
-	for y := low[1]; y <= high[1]; y++ {
-		for x := low[0]; x <= high[0]; x++ {
-			for z := low[2]; z <= high[2]; z++ {
-				blockPos := cube.Pos{x, y, z}
-				b := p.tx.Block(blockPos)
-				if collide, ok := b.(block.EntityInsider); ok {
-					collide.EntityInside(blockPos, p.tx, p)
-					if _, liquid := b.(world.Liquid); liquid {
-						continue
-					}
-				}
-
-				if l, ok := p.tx.Liquid(blockPos); ok {
-					if collide, ok := l.(block.EntityInsider); ok {
-						collide.EntityInside(blockPos, p.tx, p)
-					}
-				}
-			}
-		}
-	}
+	entity.CheckEntityInsiders(p.tx, p, entityBBox)
 }
 
 // checkEntitySteppers checks if the player is standing on any EntityStepper blocks.
@@ -2993,16 +2976,7 @@ func (p *Player) checkEntitySteppers() {
 	if !p.OnGround() {
 		return
 	}
-	low, high := p.blocksUnder()
-	for x := low[0]; x <= high[0]; x++ {
-		for z := low[2]; z <= high[2]; z++ {
-			pos := cube.Pos{x, low[1], z}
-			if stepper, ok := p.tx.Block(pos).(block.EntityStepper); ok {
-				stepper.EntityStepOn(pos, p.tx, p)
-				return
-			}
-		}
-	}
+	entity.CheckEntitySteppers(p.tx, p, Type.BBox(p).Translate(p.Position()))
 }
 
 // checkOnGround checks if the player is currently considered to be on the ground.

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -681,13 +681,7 @@ func (p *Player) applyTotemEffects() {
 // enchantments on the individual pieces.
 // The damage returned will be at the least 0.
 func (p *Player) FinalDamageFrom(dmg float64, src world.DamageSource) float64 {
-	dmg = max(dmg, 0)
-
-	dmg -= p.Armour().DamageReduction(dmg, src)
-	if res, ok := p.Effect(effect.Resistance); ok {
-		dmg *= effect.Resistance.Multiplier(src, res.Level())
-	}
-	return dmg
+	return entity.FinalDamage(dmg, src, p.armour, p.effects)
 }
 
 // Explode ...

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -65,7 +65,6 @@ type playerData struct {
 	usingSince time.Time
 
 	glideTicks   int64
-	fireTicks    int64
 	fallDistance float64
 
 	air *entity.AirSupply
@@ -112,21 +111,14 @@ type playerData struct {
 // need to play in the world.
 type Player struct {
 	*entity.Ent
-	tx     *world.Tx
-	handle *world.EntityHandle
-	data   *world.EntityData
 	*playerData
-}
-
-func (p *Player) Tx() *world.Tx {
-	return p.tx
 }
 
 // Name returns the username of the player. If the player is controlled by a client, it is the username of
 // the client. (Typically the XBOX Live name)
 func (p *Player) Name() string {
 	// TODO: This isn't correct, this will change if the nametag changes.
-	return p.data.Name
+	return p.Ent.Data().Name
 }
 
 // UUID returns the UUID of the player. This UUID will remain consistent with an XBOX Live account, and will,
@@ -134,7 +126,7 @@ func (p *Player) Name() string {
 // It is therefore recommended using the UUID over the name of the player. Additionally, it is recommended to
 // use the UUID over the XUID because of its standard format.
 func (p *Player) UUID() uuid.UUID {
-	return p.handle.UUID()
+	return p.H().UUID()
 }
 
 // XUID returns the XBOX Live user ID of the player. It will remain consistent with the XBOX Live account,
@@ -192,7 +184,7 @@ func (p *Player) Skin() skin.Skin {
 // SetSkin changes the skin of the player. This skin will be visible to other players that the player
 // is shown to.
 func (p *Player) SetSkin(skin skin.Skin) {
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleSkinChange(ctx, &skin); ctx.Cancelled() {
 		p.session().ViewSkin(p)
 		return
@@ -319,7 +311,7 @@ func (p *Player) RemoveBossBar() {
 // player and is formatted following the rules of fmt.Sprintln.
 func (p *Player) Chat(msg ...any) {
 	message := format(msg)
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleChat(ctx, &message); ctx.Cancelled() {
 		return
 	}
@@ -347,11 +339,11 @@ func (p *Player) ExecuteCommand(commandLine string) {
 		p.SendCommandOutput(o)
 		return
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleCommandExecution(ctx, command, args[1:]); ctx.Cancelled() {
 		return
 	}
-	command.Execute(strings.Join(args[1:], " "), p, p.tx)
+	command.Execute(strings.Join(args[1:], " "), p, p.Tx())
 }
 
 // Transfer transfers the player to a server at the address passed. If the address could not be resolved, an
@@ -362,7 +354,7 @@ func (p *Player) Transfer(address string) error {
 		return err
 	}
 
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleTransfer(ctx, addr); ctx.Cancelled() {
 		return nil
 	}
@@ -538,7 +530,7 @@ func (p *Player) Heal(health float64, source world.HealingSource) float64 {
 	if p.Dead() || health < 0 || !p.GameMode().AllowsTakingDamage() {
 		return 0
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleHeal(ctx, &health, source); ctx.Cancelled() {
 		return 0
 	}
@@ -565,7 +557,7 @@ func (p *Player) updateFallState(distanceThisTick float64) {
 
 // fall is called when a falling entity hits the ground.
 func (p *Player) fall(distance float64) {
-	entity.Fall(p, p.tx, p.effects, distance)
+	entity.Fall(p, p.Tx(), p.effects, distance)
 }
 
 // Hurt hurts the player for a given amount of damage. The source passed
@@ -589,7 +581,7 @@ func (p *Player) Hurt(dmg float64, src world.DamageSource) (float64, bool) {
 	}
 
 	immunity := time.Second / 2
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleHurt(ctx, &damageLeft, immune, &immunity, src); ctx.Cancelled() {
 		return 0, false
 	}
@@ -641,9 +633,9 @@ func (p *Player) Hurt(dmg float64, src world.DamageSource) (float64, bool) {
 		viewer.ViewEntityAction(p, entity.HurtAction{})
 	}
 	if src.Fire() {
-		p.tx.PlaySound(pos, sound.Burning{})
+		p.Tx().PlaySound(pos, sound.Burning{})
 	} else if _, ok := src.(entity.DrowningDamageSource); ok {
-		p.tx.PlaySound(pos, sound.Drowning{})
+		p.Tx().PlaySound(pos, sound.Drowning{})
 	}
 
 	p.Wake()
@@ -666,7 +658,7 @@ func (p *Player) applyTotemEffects() {
 	p.AddEffect(effect.New(effect.FireResistance, 1, time.Second*40))
 	p.AddEffect(effect.New(effect.Absorption, 2, time.Second*5))
 
-	p.tx.PlaySound(p.Position(), sound.Totem{})
+	p.Tx().PlaySound(p.Position(), sound.Totem{})
 
 	for _, viewer := range p.viewers() {
 		viewer.ViewEntityAction(p, entity.TotemUseAction{})
@@ -792,7 +784,7 @@ func (*Player) BeaconAffected() bool {
 // Exhaust exhausts the player by the amount of points passed if the player is in survival mode. If the total
 // exhaustion level exceeds 4, a saturation point, or food point, if saturation is 0, will be subtracted.
 func (p *Player) Exhaust(points float64) {
-	if !p.GameMode().AllowsTakingDamage() || p.tx.World().Difficulty().FoodRegenerates() {
+	if !p.GameMode().AllowsTakingDamage() || p.Tx().World().Difficulty().FoodRegenerates() {
 		return
 	}
 	before := p.hunger.Food()
@@ -801,7 +793,7 @@ func (p *Player) Exhaust(points float64) {
 		// Temporarily set the food level back so that it hasn't yet changed once the event is handled.
 		p.hunger.SetFood(before)
 
-		ctx := NewEventContext(p.tx, p)
+		ctx := NewEventContext(p.Tx(), p)
 		if p.Handler().HandleFoodLoss(ctx, before, &after); ctx.Cancelled() {
 			// Reset the exhaustion level if the event was cancelled. Because if
 			// we cancel this, and at some point we stop cancelling it, the
@@ -854,11 +846,11 @@ func (p *Player) kill(src world.DamageSource) {
 		p.RemoveEffect(e.Type())
 	}
 
-	p.deathPos, p.deathDimension = &pos, p.tx.World().Dimension()
+	p.deathPos, p.deathDimension = &pos, p.Tx().World().Dimension()
 
 	// Wait a little before removing the entity. The client displays a death
 	// animation while the player is dying.
-	DoAfter(p.handle, time.Millisecond*1100, func(_ *world.Tx, p *Player) {
+	DoAfter(p.H(), time.Millisecond*1100, func(_ *world.Tx, p *Player) {
 		finishDying(p)
 	})
 }
@@ -877,7 +869,7 @@ func finishDying(p *Player) {
 		// the movement itself yet, though.
 		pos, _, _, _ := p.spawnLocation()
 
-		p.data.Pos = pos.Vec3()
+		p.Ent.Data().Pos = pos.Vec3()
 	}
 }
 
@@ -885,7 +877,7 @@ func finishDying(p *Player) {
 func (p *Player) dropItems() {
 	pos := p.Position()
 	for _, orb := range entity.NewExperienceOrbs(pos, int(math.Min(float64(p.experience.Level()*7), 100))) {
-		p.tx.AddEntity(orb)
+		p.Tx().AddEntity(orb)
 	}
 	p.experience.Reset()
 	p.session().SendExperience(p.ExperienceLevel(), p.ExperienceProgress())
@@ -896,7 +888,7 @@ func (p *Player) dropItems() {
 			continue
 		}
 		opts := world.EntitySpawnOpts{Position: pos, Velocity: mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1}}
-		p.tx.AddEntity(entity.NewItem(opts, it))
+		p.Tx().AddEntity(entity.NewItem(opts, it))
 	}
 }
 
@@ -921,7 +913,7 @@ func (p *Player) MoveItemsToInventory() {
 // a call to Respawn.
 func (p *Player) Respawn() *world.EntityHandle {
 	p.respawn(nil)
-	return p.handle
+	return p.H()
 }
 
 // respawn heals the player and moves it to its spawn position. f, if
@@ -949,8 +941,8 @@ func (p *Player) respawn(f func(p *Player)) {
 	p.Handler().HandleRespawn(p, &pos, &w)
 
 	sess := p.session()
-	src := p.tx.World()
-	handle := p.tx.RemoveEntity(p)
+	src := p.Tx().World()
+	handle := p.Tx().RemoveEntity(p)
 	// restore re-adds the player through tx and finishes with f or the normal
 	// quit path; the fallback branches below share it.
 	restore := func(tx *world.Tx) {
@@ -973,7 +965,7 @@ func (p *Player) respawn(f func(p *Player)) {
 	if errors.Is(task.Err(), world.ErrWorldClosed) {
 		// The destination refused synchronously: re-add through the still-open
 		// source context. This also keeps synchronous worlds fully inline.
-		restore(p.tx)
+		restore(p.Tx())
 		return
 	}
 	task.OnDone(func(err error) {
@@ -1000,7 +992,7 @@ func (p *Player) respawn(f func(p *Player)) {
 
 // spawnLocation designates a players safe spawn location.
 func (p *Player) spawnLocation() (playerSpawn cube.Pos, w *world.World, spawnBlockBroken bool, previousDimension world.Dimension) {
-	tx := p.tx
+	tx := p.Tx()
 	w = tx.World()
 	previousDimension = w.Dimension()
 	playerSpawn = w.PlayerSpawn(p.UUID())
@@ -1025,7 +1017,7 @@ func (p *Player) StartSprinting() {
 	if !p.hunger.canSprint() && p.GameMode().AllowsTakingDamage() || p.crawling || p.sprinting {
 		return
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleToggleSprint(ctx, true); ctx.Cancelled() {
 		return
 	}
@@ -1045,7 +1037,7 @@ func (p *Player) StopSprinting() {
 	if !p.sprinting {
 		return
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleToggleSprint(ctx, false); ctx.Cancelled() {
 		return
 	}
@@ -1061,7 +1053,7 @@ func (p *Player) StartSneaking() {
 	if p.sneaking {
 		return
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleToggleSneak(ctx, true); ctx.Cancelled() {
 		return
 	}
@@ -1083,7 +1075,7 @@ func (p *Player) StopSneaking() {
 	if !p.sneaking {
 		return
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleToggleSneak(ctx, false); ctx.Cancelled() {
 		return
 	}
@@ -1131,7 +1123,7 @@ func (p *Player) StartCrawling() {
 		return
 	}
 	for _, corner := range p.H().Type().BBox(p).Translate(p.Position()).Corners() {
-		if _, isAir := p.tx.Block(cube.PosFromVec3(corner).Add(cube.Pos{0, 1, 0})).(block.Air); !isAir {
+		if _, isAir := p.Tx().Block(cube.PosFromVec3(corner).Add(cube.Pos{0, 1, 0})).(block.Air); !isAir {
 			p.crawling = true
 			break
 		}
@@ -1219,7 +1211,7 @@ func (p *Player) Jump() {
 		if e, ok := p.Effect(effect.JumpBoost); ok {
 			jumpVel = float64(e.Level()) / 10
 		}
-		p.data.Vel = mgl64.Vec3{0, jumpVel}
+		p.Ent.Data().Vel = mgl64.Vec3{0, jumpVel}
 	}
 	if p.Sprinting() {
 		p.Exhaust(0.2)
@@ -1236,14 +1228,14 @@ func (p *Player) Sleep(pos cube.Pos) {
 		return
 	}
 
-	tx := p.tx
+	tx := p.Tx()
 	b, ok := tx.Block(pos).(block.Bed)
 	if !ok || b.Sleeper != nil {
 		// The player cannot sleep here.
 		return
 	}
 
-	ctx, sendReminder := NewEventContext(p.tx, p), true
+	ctx, sendReminder := NewEventContext(p.Tx(), p), true
 	if p.Handler().HandleSleep(ctx, &sendReminder); ctx.Cancelled() {
 		return
 	}
@@ -1253,7 +1245,7 @@ func (p *Player) Sleep(pos cube.Pos) {
 
 	tx.World().SetRequiredSleepDuration(time.Millisecond * 5050)
 
-	p.data.Pos = pos.Vec3Middle().Add(mgl64.Vec3{0, 0.5625})
+	p.Ent.Data().Pos = pos.Vec3Middle().Add(mgl64.Vec3{0, 0.5625})
 	p.sleeping = true
 	p.sleepPos = pos
 
@@ -1274,7 +1266,7 @@ func (p *Player) Wake() {
 	}
 	p.sleeping = false
 
-	tx := p.tx
+	tx := p.Tx()
 	tx.BroadcastSleepingIndicator()
 
 	for _, v := range p.viewers() {
@@ -1359,11 +1351,6 @@ func (p *Player) FireProof() bool {
 	return !p.GameMode().AllowsTakingDamage()
 }
 
-// OnFireDuration ...
-func (p *Player) OnFireDuration() time.Duration {
-	return time.Duration(p.fireTicks) * time.Second / 20
-}
-
 // SetOnFire ...
 func (p *Player) SetOnFire(duration time.Duration) {
 	ticks := int64(duration.Seconds() * 20)
@@ -1372,13 +1359,12 @@ func (p *Player) SetOnFire(duration time.Duration) {
 	}
 
 	duration = time.Duration(ticks) * time.Second / 20
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleSetOnFire(ctx, &duration); ctx.Cancelled() {
 		return
 	}
 
-	ticks = int64(duration.Seconds() * 20)
-	p.fireTicks = ticks
+	p.Ent.Data().FireDuration = max(time.Duration(int64(duration.Seconds()*20))*time.Second/20, 0)
 	p.updateState()
 }
 
@@ -1430,7 +1416,7 @@ func (p *Player) SetHeldSlot(to int) error {
 		return nil
 	}
 
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	p.Handler().HandleHeldSlotChange(ctx, from, to)
 	if ctx.Cancelled() {
 		// The slot change was cancelled, resend held slot.
@@ -1517,7 +1503,7 @@ func (p *Player) SetCooldown(item world.Item, cooldown time.Duration) {
 // This generally happens for items such as throwable items like snowballs.
 func (p *Player) UseItem() {
 	i, _ := p.HeldItems()
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.HasCooldown(i.Item()) {
 		return
 	}
@@ -1542,7 +1528,7 @@ func (p *Player) UseItem() {
 	case item.Chargeable:
 		useCtx := p.useContext()
 		if !p.usingItem {
-			if !usable.ReleaseCharge(p, p.tx, useCtx) && usable.CanCharge(p, p.tx, useCtx) {
+			if !usable.ReleaseCharge(p, p.Tx(), useCtx) && usable.CanCharge(p, p.Tx(), useCtx) {
 				// If the item was not charged yet, start charging.
 				p.usingSince, p.usingItem = time.Now(), true
 			}
@@ -1554,14 +1540,14 @@ func (p *Player) UseItem() {
 		// Stop charging and determine if the item is ready.
 		p.usingItem = false
 		dur := p.useDuration()
-		if usable.Charge(p, p.tx, useCtx, dur) {
+		if usable.Charge(p, p.Tx(), useCtx, dur) {
 			p.session().SendChargeItemComplete()
 		}
 		p.handleUseContext(useCtx)
 		p.updateState()
 	case item.Usable:
 		useCtx := p.useContext()
-		if !usable.Use(p.tx, p, useCtx) {
+		if !usable.Use(p.Tx(), p, useCtx) {
 			return
 		}
 		// We only swing the player's arm if the item held actually does something. If it doesn't, there is no
@@ -1595,13 +1581,13 @@ func (p *Player) UseItem() {
 		}
 		// Reset the duration for the next item to be consumed.
 		p.usingSince = time.Now()
-		ctx := NewEventContext(p.tx, p)
+		ctx := NewEventContext(p.Tx(), p)
 		if p.Handler().HandleItemConsume(ctx, i); ctx.Cancelled() {
 			return
 		}
-		useCtx.CountSub, useCtx.NewItem = 1, usable.Consume(p.tx, p)
+		useCtx.CountSub, useCtx.NewItem = 1, usable.Consume(p.Tx(), p)
 		p.handleUseContext(useCtx)
-		p.tx.PlaySound(p.Position().Add(mgl64.Vec3{0, 1.5}), sound.Burp{})
+		p.Tx().PlaySound(p.Position().Add(mgl64.Vec3{0, 1.5}), sound.Burp{})
 	}
 }
 
@@ -1619,11 +1605,11 @@ func (p *Player) ReleaseItem() {
 
 	useCtx, dur := p.useContext(), p.useDuration()
 	i, _ := p.HeldItems()
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleItemRelease(ctx, i, dur); ctx.Cancelled() {
 		return
 	}
-	i.Item().(item.Releasable).Release(p, p.tx, useCtx, dur)
+	i.Item().(item.Releasable).Release(p, p.Tx(), useCtx, dur)
 	p.handleUseContext(useCtx)
 	p.updateState()
 }
@@ -1696,26 +1682,26 @@ func (p *Player) UsingItem() bool {
 // returns immediately.
 // UseItemOnBlock does nothing if the block at the cube.Pos passed is of the type block.Air.
 func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec3) {
-	if _, ok := p.tx.Block(pos).(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
+	if _, ok := p.Tx().Block(pos).(block.Air); ok || !p.canReach(pos.Vec3Centre()) {
 		// The client used its item on a block that does not exist server-side or one it couldn't reach. Stop trying
 		// to use the item immediately.
 		p.resendNearbyBlocks(pos, face)
 		return
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleItemUseOnBlock(ctx, pos, face, clickPos); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos, face)
 		return
 	}
 	i, left := p.HeldItems()
-	b := p.tx.Block(pos)
+	b := p.Tx().Block(pos)
 	if act, ok := b.(block.Activatable); ok {
 		// If a player is sneaking, it will not activate the block clicked, unless it is not holding any
 		// items, in which case the block will be activated as usual.
 		if !p.Sneaking() || i.Empty() {
 			// The block was activated: Blocks such as doors must always have precedence over the item being
 			// used.
-			if useCtx := p.useContext(); act.Activate(pos, face, p.tx, p, useCtx) {
+			if useCtx := p.useContext(); act.Activate(pos, face, p.Tx(), p, useCtx) {
 				p.SwingArm()
 				p.SetHeldItems(p.subtractItem(p.damageItem(i, useCtx.Damage), useCtx.CountSub), left)
 				p.addNewItem(useCtx)
@@ -1730,7 +1716,7 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 	case item.UsableOnBlock:
 		// The item does something when used on a block.
 		useCtx := p.useContext()
-		if !ib.UseOnBlock(pos, face, clickPos, p.tx, p, useCtx) {
+		if !ib.UseOnBlock(pos, face, clickPos, p.Tx(), p, useCtx) {
 			return
 		}
 		p.SwingArm()
@@ -1743,7 +1729,7 @@ func (p *Player) UseItemOnBlock(pos cube.Pos, face cube.Face, clickPos mgl64.Vec
 			// The block clicked was either not replaceable, or not replaceable using the block passed.
 			replacedPos = pos.Side(face)
 		}
-		if replaceable, ok := p.tx.Block(replacedPos).(block.Replaceable); !ok || !replaceable.ReplaceableBy(ib) || replacedPos.OutOfBounds(p.tx.Range()) {
+		if replaceable, ok := p.Tx().Block(replacedPos).(block.Replaceable); !ok || !replaceable.ReplaceableBy(ib) || replacedPos.OutOfBounds(p.Tx().Range()) {
 			return
 		}
 		if !p.placeBlock(replacedPos, ib, false) || p.GameMode().CreativeInventory() {
@@ -1760,7 +1746,7 @@ func (p *Player) UseItemOnEntity(e world.Entity) bool {
 	if !p.canReach(e.Position()) {
 		return false
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleItemUseOnEntity(ctx, e); ctx.Cancelled() {
 		return false
 	}
@@ -1770,7 +1756,7 @@ func (p *Player) UseItemOnEntity(e world.Entity) bool {
 		return true
 	}
 	useCtx := p.useContext()
-	if !usable.UseOnEntity(e, p.tx, p, useCtx) {
+	if !usable.UseOnEntity(e, p.Tx(), p, useCtx) {
 		return true
 	}
 	p.SwingArm()
@@ -1808,7 +1794,7 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 		height += inc
 	}
 
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleAttackEntity(ctx, e, &force, &height, &critical); ctx.Cancelled() {
 		return false
 	}
@@ -1823,7 +1809,7 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 			p.SetHeldItems(p.damageItem(i, durable.DurabilityInfo().AttackDurability), left)
 		}
 		n, vulnerable, _ := entity.HurtEntity(e, i.AttackDamage(), entity.AttackDamageSource{Attacker: p})
-		p.tx.PlaySound(entity.EyePosition(e), sound.Attack{Damage: !mgl64.FloatEqual(n, 0)})
+		p.Tx().PlaySound(entity.EyePosition(e), sound.Attack{Damage: !mgl64.FloatEqual(n, 0)})
 		if vulnerable {
 			p.Exhaust(0.1)
 		}
@@ -1839,7 +1825,7 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 	}
 	if s, ok := i.Enchantment(enchantment.Sharpness); ok {
 		dmg += enchantment.Sharpness.Addend(s.Level())
-		for _, v := range p.tx.Viewers(living.Position()) {
+		for _, v := range p.Tx().Viewers(living.Position()) {
 			v.ViewEntityAction(living, entity.EnchantedHitAction{})
 		}
 	}
@@ -1854,12 +1840,12 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 		p.SetHeldItems(p.damageItem(i, durable.DurabilityInfo().AttackDurability), left)
 	}
 
-	p.tx.PlaySound(entity.EyePosition(e), sound.Attack{Damage: !mgl64.FloatEqual(n, 0)})
+	p.Tx().PlaySound(entity.EyePosition(e), sound.Attack{Damage: !mgl64.FloatEqual(n, 0)})
 	if !vulnerable {
 		return true
 	}
 	if critical {
-		for _, v := range p.tx.Viewers(living.Position()) {
+		for _, v := range p.Tx().Viewers(living.Position()) {
 			v.ViewEntityAction(living, entity.CriticalHitAction{})
 		}
 	}
@@ -1883,20 +1869,20 @@ func (p *Player) AttackEntity(e world.Entity) bool {
 // player might be breaking before this method is called.
 func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	p.AbortBreaking()
-	if _, air := p.tx.Block(pos).(block.Air); air || !p.canReach(pos.Vec3Centre()) {
+	if _, air := p.Tx().Block(pos).(block.Air); air || !p.canReach(pos.Vec3Centre()) {
 		// The block was either out of range or air, so it can't be broken by the player.
 		return
 	}
-	if _, ok := p.tx.Block(pos.Side(face)).(block.Fire); ok {
-		ctx := NewEventContext(p.tx, p)
+	if _, ok := p.Tx().Block(pos.Side(face)).(block.Fire); ok {
+		ctx := NewEventContext(p.Tx(), p)
 		if p.Handler().HandleFireExtinguish(ctx, pos); ctx.Cancelled() {
 			// Resend the block because on client side that was extinguished
 			p.resendNearbyBlocks(pos, face)
 			return
 		}
 
-		p.tx.SetBlock(pos.Side(face), nil, nil)
-		p.tx.PlaySound(pos.Vec3(), sound.FireExtinguish{})
+		p.Tx().SetBlock(pos.Side(face), nil, nil)
+		p.Tx().PlaySound(pos.Vec3(), sound.FireExtinguish{})
 		return
 	}
 
@@ -1909,12 +1895,12 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 	// can resend the block to the client when it tries to break the block regardless.
 	p.breakingPos = pos
 
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleStartBreak(ctx, pos); ctx.Cancelled() {
 		return
 	}
-	if punchable, ok := p.tx.Block(pos).(block.Punchable); ok {
-		punchable.Punch(pos, face, p.tx, p)
+	if punchable, ok := p.Tx().Block(pos).(block.Punchable); ok {
+		punchable.Punch(pos, face, p.Tx(), p)
 	}
 
 	p.breaking, p.breakingFace = true, face
@@ -1933,7 +1919,7 @@ func (p *Player) StartBreaking(pos cube.Pos, face cube.Face) {
 // held, if the player is on the ground/underwater and if the player has any effects.
 func (p *Player) breakTime(pos cube.Pos) time.Duration {
 	held, _ := p.HeldItems()
-	return block.BreakDuration(p.tx.Block(pos), held, p.breakContext())
+	return block.BreakDuration(p.Tx().Block(pos), held, p.breakContext())
 }
 
 // breakContext returns the block.BreakContext describing the status effects and environment currently
@@ -1941,7 +1927,7 @@ func (p *Player) breakTime(pos cube.Pos) time.Duration {
 func (p *Player) breakContext() block.BreakContext {
 	_, aquaAffinity := p.Armour().Helmet().Enchantment(enchantment.AquaAffinity)
 	ctx := block.BreakContext{
-		Underwater:   entity.Submerged(p, p.tx),
+		Underwater:   entity.Submerged(p, p.Tx()),
 		AquaAffinity: aquaAffinity,
 		Airborne:     !p.OnGround(),
 		Flying:       p.Flying(),
@@ -1991,15 +1977,15 @@ func (p *Player) ContinueBreaking(face cube.Face) {
 		return
 	}
 	pos := p.breakingPos
-	b := p.tx.Block(pos)
-	p.tx.AddParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
+	b := p.Tx().Block(pos)
+	p.Tx().AddParticle(pos.Vec3(), particle.PunchBlock{Block: b, Face: face})
 
 	if p.breakCounter++; p.breakCounter%5 == 0 {
 		p.SwingArm()
 
 		// We send this sound only every so often. Vanilla doesn't send it every tick while breaking
 		// either. Every 5 ticks seems accurate.
-		p.tx.PlaySound(pos.Vec3(), sound.BlockBreaking{Block: b})
+		p.Tx().PlaySound(pos.Vec3(), sound.BlockBreaking{Block: b})
 	}
 	if breakTime := p.breakTime(pos); breakTime != p.lastBreakDuration {
 		for _, viewer := range p.viewers() {
@@ -2040,13 +2026,13 @@ func (p *Player) placeBlock(pos cube.Pos, b world.Block, ignoreBBox bool) bool {
 		return false
 	}
 
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleBlockPlace(ctx, pos, b); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos, cube.Faces()...)
 		return false
 	}
-	p.tx.SetBlock(pos, b, nil)
-	p.tx.PlaySound(pos.Vec3(), sound.BlockPlace{Block: b})
+	p.Tx().SetBlock(pos, b, nil)
+	p.Tx().PlaySound(pos.Vec3(), sound.BlockPlace{Block: b})
 	p.SwingArm()
 	return true
 }
@@ -2058,12 +2044,12 @@ func (p *Player) placeBlock(pos cube.Pos, b world.Block, ignoreBBox bool) bool {
 // If the only entity preventing the block from being placed is the player
 // itself, the second bool returned is true too.
 func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnly bool) {
-	blockBoxes := b.Model().BBox(pos, p.tx)
+	blockBoxes := b.Model().BBox(pos, p.Tx())
 	for i, box := range blockBoxes {
 		blockBoxes[i] = box.Translate(pos.Vec3())
 	}
 
-	for e := range p.tx.EntitiesWithin(cube.Box(-3, -3, -3, 3, 3, 3).Translate(pos.Vec3())) {
+	for e := range p.Tx().EntitiesWithin(cube.Box(-3, -3, -3, 3, 3, 3).Translate(pos.Vec3())) {
 		t := e.H().Type()
 		switch t {
 		case entity.ItemType, entity.ArrowType, entity.ExperienceOrbType:
@@ -2071,7 +2057,7 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 		default:
 			if cube.AnyIntersections(blockBoxes, t.BBox(e).Translate(e.Position()).Grow(-1e-4)) {
 				obstructed = true
-				if e.H() == p.handle {
+				if e.H() == p.H() {
 					continue
 				}
 				return true, false
@@ -2084,7 +2070,7 @@ func (p *Player) obstructedPos(pos cube.Pos, b world.Block) (obstructed, selfOnl
 // BreakBlock makes the player break a block in the world at a position passed. If the player is unable to
 // reach the block passed, the method returns immediately.
 func (p *Player) BreakBlock(pos cube.Pos) {
-	b := p.tx.Block(pos)
+	b := p.Tx().Block(pos)
 	if _, air := b.(block.Air); air {
 		// Don't do anything if the position broken is already air.
 		return
@@ -2107,7 +2093,7 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 		}
 	}
 
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleBlockBreak(ctx, pos, &drops, &xp); ctx.Cancelled() {
 		p.resendNearbyBlocks(pos)
 		return
@@ -2115,21 +2101,21 @@ func (p *Player) BreakBlock(pos cube.Pos) {
 	held, left := p.HeldItems()
 
 	p.SwingArm()
-	p.tx.SetBlock(pos, nil, nil)
-	p.tx.AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
+	p.Tx().SetBlock(pos, nil, nil)
+	p.Tx().AddParticle(pos.Vec3Centre(), particle.BlockBreak{Block: b})
 
 	if breakable, ok := b.(block.Breakable); ok {
 		info := breakable.BreakInfo()
 		if info.BreakHandler != nil {
-			info.BreakHandler(pos, p.tx, p)
+			info.BreakHandler(pos, p.Tx(), p)
 		}
 		for _, orb := range entity.NewExperienceOrbs(pos.Vec3Centre(), xp) {
-			p.tx.AddEntity(orb)
+			p.Tx().AddEntity(orb)
 		}
 	}
 	for _, drop := range drops {
 		opts := world.EntitySpawnOpts{Position: pos.Vec3Centre(), Velocity: mgl64.Vec3{rand.Float64()*0.2 - 0.1, 0.2, rand.Float64()*0.2 - 0.1}}
-		p.tx.AddEntity(entity.NewItem(opts, drop))
+		p.Tx().AddEntity(entity.NewItem(opts, drop))
 	}
 
 	p.Exhaust(0.005)
@@ -2167,7 +2153,7 @@ func (p *Player) PickBlock(pos cube.Pos) {
 		return
 	}
 
-	b := p.tx.Block(pos)
+	b := p.Tx().Block(pos)
 
 	var pickedItem item.Stack
 	if pi, ok := b.(block.Pickable); ok {
@@ -2184,7 +2170,7 @@ func (p *Player) PickBlock(pos cube.Pos) {
 		return
 	}
 
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleBlockPick(ctx, pos, b); ctx.Cancelled() {
 		return
 	}
@@ -2216,7 +2202,7 @@ func (p *Player) PickBlock(pos cube.Pos) {
 // Teleport teleports the player to a target position in the world. Unlike Move, it immediately changes the
 // position of the player, rather than showing an animation.
 func (p *Player) Teleport(pos mgl64.Vec3) {
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleTeleport(ctx, pos); ctx.Cancelled() {
 		return
 	}
@@ -2235,8 +2221,8 @@ func (p *Player) teleport(pos mgl64.Vec3) {
 	for _, v := range p.viewers() {
 		v.ViewEntityTeleport(p, pos)
 	}
-	p.data.Pos = pos
-	p.data.Vel = mgl64.Vec3{}
+	p.Ent.Data().Pos = pos
+	p.Ent.Data().Vel = mgl64.Vec3{}
 	p.ResetFallDistance()
 }
 
@@ -2261,7 +2247,7 @@ func (p *Player) Move(deltaPos mgl64.Vec3, deltaYaw, deltaPitch float64) {
 		pos         = p.Position()
 		res, resRot = pos.Add(deltaPos), p.Rotation().Add(cube.Rotation{deltaYaw, deltaPitch})
 	)
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleMove(ctx, res, resRot); ctx.Cancelled() {
 		if p.session() != session.Nop && pos.ApproxEqual(p.Position()) {
 			// The position of the player was changed and the event cancelled. This means we still need to notify the
@@ -2274,11 +2260,11 @@ func (p *Player) Move(deltaPos mgl64.Vec3, deltaYaw, deltaPitch float64) {
 		v.ViewEntityMovement(p, res, resRot, p.OnGround())
 	}
 
-	p.data.Pos = res
-	p.data.Rot = resRot
+	p.Ent.Data().Pos = res
+	p.Ent.Data().Rot = resRot
 	if deltaPos.Len() <= 3 {
 		// Only update velocity if the player is not moving too fast to prevent potential OOMs.
-		p.data.Vel = deltaPos
+		p.Ent.Data().Vel = deltaPos
 		p.checkBlockCollisions(deltaPos)
 	}
 
@@ -2290,14 +2276,14 @@ func (p *Player) Move(deltaPos mgl64.Vec3, deltaYaw, deltaPitch float64) {
 		}
 		if p.collidedHorizontally {
 			if force := horizontalVel.Len()*10.0 - 3.0; force > 0.0 {
-				p.tx.PlaySound(p.Position(), sound.Fall{Distance: force})
+				p.Tx().PlaySound(p.Position(), sound.Fall{Distance: force})
 				p.Hurt(force, entity.GlideDamageSource{})
 			}
 		}
 	}
 
-	_, submergedBefore := p.tx.Liquid(cube.PosFromVec3(pos.Add(mgl64.Vec3{0, p.EyeHeight()})))
-	_, submergedAfter := p.tx.Liquid(cube.PosFromVec3(res.Add(mgl64.Vec3{0, p.EyeHeight()})))
+	_, submergedBefore := p.Tx().Liquid(cube.PosFromVec3(pos.Add(mgl64.Vec3{0, p.EyeHeight()})))
+	_, submergedAfter := p.Tx().Liquid(cube.PosFromVec3(res.Add(mgl64.Vec3{0, p.EyeHeight()})))
 	if submergedBefore != submergedAfter {
 		// Player wasn't either breathing before and no longer isn't, or wasn't breathing before and now is,
 		// so send the updated metadata.
@@ -2320,7 +2306,7 @@ func (p *Player) Displace(deltaPos mgl64.Vec3) {
 		return
 	}
 	pos := p.Position()
-	deltaPos, velocity := p.mc.CheckCollision(p.tx, p, pos, deltaPos)
+	deltaPos, velocity := p.mc.CheckCollision(p.Tx(), p, pos, deltaPos)
 	if deltaPos.ApproxEqual(mgl64.Vec3{}) {
 		return
 	}
@@ -2328,7 +2314,7 @@ func (p *Player) Displace(deltaPos mgl64.Vec3) {
 	for _, v := range p.viewers() {
 		v.ViewEntityDisplacement(p, res, p.Rotation(), p.OnGround())
 	}
-	p.data.Pos, p.data.Vel = res, velocity
+	p.Ent.Data().Pos, p.Ent.Data().Vel = res, velocity
 	p.checkBlockCollisions(deltaPos)
 	p.onGround = p.checkOnGround(deltaPos)
 	p.updateFallState(deltaPos[1])
@@ -2338,7 +2324,7 @@ func (p *Player) Displace(deltaPos mgl64.Vec3) {
 // the velocity to the player session for the player to update.
 func (p *Player) SetVelocity(velocity mgl64.Vec3) {
 	if p.session() == session.Nop {
-		p.data.Vel = velocity
+		p.Ent.Data().Vel = velocity
 		return
 	}
 	for _, v := range p.viewers() {
@@ -2352,7 +2338,7 @@ func (p *Player) Collect(s item.Stack) (int, bool) {
 	if p.Dead() || !p.GameMode().AllowsInteraction() {
 		return 0, false
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleItemPickup(ctx, &s); ctx.Cancelled() {
 		return 0, false
 	}
@@ -2384,7 +2370,7 @@ func (p *Player) ResetEnchantmentSeed() {
 
 // AddExperience adds experience to the player.
 func (p *Player) AddExperience(amount int) int {
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleExperienceGain(ctx, &amount); ctx.Cancelled() {
 		return 0
 	}
@@ -2505,12 +2491,12 @@ func (p *Player) mendItems(xp int) int {
 // The number of items that was dropped in the end is returned. It is generally the count of the stack passed
 // or 0 if dropping the item.Stack was cancelled.
 func (p *Player) Drop(s item.Stack) int {
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleItemDrop(ctx, s); ctx.Cancelled() {
 		return 0
 	}
 	opts := world.EntitySpawnOpts{Position: p.Position().Add(mgl64.Vec3{0, 1.4}), Velocity: p.Rotation().Vec3().Mul(0.4)}
-	p.tx.AddEntity(entity.NewItemPickupDelay(opts, s, time.Second*2))
+	p.Tx().AddEntity(entity.NewItemPickupDelay(opts, s, time.Second*2))
 	return s.Count()
 }
 
@@ -2555,7 +2541,7 @@ func (p *Player) Tick(tx *world.Tx, current int64) {
 	if p.Dead() {
 		return
 	}
-	if _, ok := p.tx.Liquid(cube.PosFromVec3(p.Position())); !ok {
+	if _, ok := p.Tx().Liquid(cube.PosFromVec3(p.Position())); !ok {
 		p.StopSwimming()
 		if _, ok := p.Armour().Helmet().Item().(item.TurtleShell); ok {
 			p.AddEffect(effect.New(effect.WaterBreathing, 1, time.Second*10).WithoutParticles())
@@ -2572,30 +2558,28 @@ func (p *Player) Tick(tx *world.Tx, current int64) {
 		}
 	}
 
-	p.checkBlockCollisions(p.data.Vel)
+	p.checkBlockCollisions(p.Ent.Data().Vel)
 	p.onGround = p.checkOnGround(mgl64.Vec3{})
 	p.Ent.Data().Age += time.Second / 20
 	p.checkEntitySteppers()
 
-	p.effects.Tick(p, p.tx)
+	p.effects.Tick(p, p.Tx())
 
 	p.tickFood()
 	p.tickAirSupply()
 
-	if p.Position()[1] < float64(p.tx.Range()[0]) {
+	if p.Position()[1] < float64(p.Tx().Range()[0]) {
 		p.Hurt(4, entity.VoidDamageSource{})
 	}
-	if entity.InsideOfSolid(p, p.tx) {
+	if entity.InsideOfSolid(p, p.Tx()) {
 		p.Hurt(1, entity.SuffocationDamageSource{})
 	}
 
 	if p.OnFireDuration() > 0 {
-		p.fireTicks -= 1
-		if !p.GameMode().AllowsTakingDamage() || p.OnFireDuration() <= 0 || p.tx.RainingAt(cube.PosFromVec3(p.Position())) {
+		entity.TickOnFire(p, p.Tx())
+		p.Ent.Data().FireDuration -= time.Second / 20
+		if !p.GameMode().AllowsTakingDamage() || p.OnFireDuration() <= 0 {
 			p.Extinguish()
-		}
-		if p.OnFireDuration()%time.Second == 0 {
-			p.Hurt(1, block.FireDamageSource{})
 		}
 	}
 
@@ -2633,13 +2617,13 @@ func (p *Player) Tick(tx *world.Tx, current int64) {
 	p.prevWorld = tx.World()
 
 	if p.session() == session.Nop && !p.Immobile() {
-		m := p.mc.TickMovement(p, p.Position(), p.Velocity(), p.Rotation(), p.tx)
+		m := p.mc.TickMovement(p, p.Position(), p.Velocity(), p.Rotation(), p.Tx())
 		m.Send()
 
-		p.data.Vel = m.Velocity()
+		p.Ent.Data().Vel = m.Velocity()
 		p.Move(m.Position().Sub(p.Position()), 0, 0)
 	} else {
-		p.data.Vel = mgl64.Vec3{}
+		p.Ent.Data().Vel = mgl64.Vec3{}
 	}
 
 	p.portalTravel.StopPortalContact()
@@ -2713,8 +2697,8 @@ func (p *Player) tickAirSupply() {
 // tickFood ticks food related functionality, such as the depletion of the food bar and regeneration if it
 // is full enough.
 func (p *Player) tickFood() {
-	if p.hunger.foodTick%10 == 0 && (p.hunger.canQuicklyRegenerate() || p.tx.World().Difficulty().FoodRegenerates()) {
-		if p.tx.World().Difficulty().FoodRegenerates() {
+	if p.hunger.foodTick%10 == 0 && (p.hunger.canQuicklyRegenerate() || p.Tx().World().Difficulty().FoodRegenerates()) {
+		if p.Tx().World().Difficulty().FoodRegenerates() {
 			p.AddFood(1)
 		}
 		if p.hunger.foodTick%20 == 0 {
@@ -2723,7 +2707,7 @@ func (p *Player) tickFood() {
 	}
 	if p.hunger.foodTick == 1 {
 		if p.hunger.canRegenerate() {
-			p.regenerate(!p.tx.World().Difficulty().FoodRegenerates())
+			p.regenerate(!p.Tx().World().Difficulty().FoodRegenerates())
 		} else if p.hunger.starving() {
 			p.starve()
 		}
@@ -2755,7 +2739,7 @@ func (p *Player) regenerate(exhaust bool) {
 // mode, damage will only be dealt if the player has more than 2 health and in hard mode, damage will always
 // be dealt.
 func (p *Player) starve() {
-	if p.Health() > p.tx.World().Difficulty().StarvationHealthLimit() {
+	if p.Health() > p.Tx().World().Difficulty().StarvationHealthLimit() {
 		p.Hurt(1, StarvationDamageSource{})
 	}
 }
@@ -2787,7 +2771,7 @@ func (p *Player) canBreathe() bool {
 	canTakeDamage := p.GameMode().AllowsTakingDamage()
 	_, waterBreathing := p.effects.Effect(effect.WaterBreathing)
 	_, conduitPower := p.effects.Effect(effect.ConduitPower)
-	return !canTakeDamage || waterBreathing || conduitPower || (!entity.Submerged(p, p.tx) && !entity.InsideOfSolid(p, p.tx))
+	return !canTakeDamage || waterBreathing || conduitPower || (!entity.Submerged(p, p.Tx()) && !entity.InsideOfSolid(p, p.Tx()))
 }
 
 // checkCollisions checks the player's block collisions.
@@ -2808,7 +2792,7 @@ func (p *Player) checkBlockCollisions(vel mgl64.Vec3) {
 		for x := minX; x <= maxX; x++ {
 			for z := minZ; z <= maxZ; z++ {
 				pos := cube.Pos{x, y, z}
-				boxes := p.tx.Block(pos).Model().BBox(pos, p.tx)
+				boxes := p.Tx().Block(pos).Model().BBox(pos, p.Tx())
 				for _, box := range boxes {
 					blocks = append(blocks, box.Translate(pos.Vec3()))
 				}
@@ -2846,7 +2830,7 @@ func (p *Player) checkBlockCollisions(vel mgl64.Vec3) {
 
 // checkEntityInsiders checks if the player is colliding with any EntityInsider blocks.
 func (p *Player) checkEntityInsiders(entityBBox cube.BBox) {
-	entity.CheckEntityInsiders(p.tx, p, entityBBox)
+	entity.CheckEntityInsiders(p.Tx(), p, entityBBox)
 }
 
 // checkEntitySteppers checks if the player is standing on any EntityStepper blocks.
@@ -2854,7 +2838,7 @@ func (p *Player) checkEntitySteppers() {
 	if !p.OnGround() {
 		return
 	}
-	entity.CheckEntitySteppers(p.tx, p, Type.BBox(p).Translate(p.Position()))
+	entity.CheckEntitySteppers(p.Tx(), p, Type.BBox(p).Translate(p.Position()))
 }
 
 // checkOnGround checks if the player is currently considered to be on the ground.
@@ -2868,7 +2852,7 @@ func (p *Player) checkOnGround(deltaPos mgl64.Vec3) bool {
 		for z := low[2]; z <= high[2]; z++ {
 			for y := low[1]; y < high[1]; y++ {
 				pos := cube.Pos{x, y, z}
-				for _, bb := range p.tx.Block(pos).Model().BBox(pos, p.tx) {
+				for _, bb := range p.Tx().Block(pos).Model().BBox(pos, p.Tx()) {
 					if bb.Translate(pos.Vec3()).IntersectsWith(box) {
 						return true
 					}
@@ -2939,7 +2923,7 @@ func (p *Player) OpenSign(pos cube.Pos, frontSide bool) {
 // EditSign edits the sign at the cube.Pos passed and writes the text passed to a sign at that position. If no sign is
 // present, an error is returned.
 func (p *Player) EditSign(pos cube.Pos, frontText, backText string) error {
-	sign, ok := p.tx.Block(pos).(block.Sign)
+	sign, ok := p.Tx().Block(pos).(block.Sign)
 	if !ok {
 		return fmt.Errorf("edit sign: no sign at position %v", pos)
 	}
@@ -2950,7 +2934,7 @@ func (p *Player) EditSign(pos cube.Pos, frontText, backText string) error {
 		return nil
 	}
 
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if frontText != sign.Front.Text {
 		if p.Handler().HandleSignEdit(ctx, pos, true, sign.Front.Text, frontText); ctx.Cancelled() {
 			p.resendNearbyBlock(pos)
@@ -2966,25 +2950,25 @@ func (p *Player) EditSign(pos cube.Pos, frontText, backText string) error {
 		sign.Back.Text = backText
 		sign.Back.Owner = p.XUID()
 	}
-	p.tx.SetBlock(pos, sign, nil)
+	p.Tx().SetBlock(pos, sign, nil)
 	return nil
 }
 
 // TurnLecternPage edits the lectern at the cube.Pos passed by turning the page to the page passed. If no lectern is
 // present, an error is returned.
 func (p *Player) TurnLecternPage(pos cube.Pos, page int) error {
-	lectern, ok := p.tx.Block(pos).(block.Lectern)
+	lectern, ok := p.Tx().Block(pos).(block.Lectern)
 	if !ok {
 		return fmt.Errorf("edit lectern: no lectern at position %v", pos)
 	}
 
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleLecternPageTurn(ctx, pos, lectern.Page, &page); ctx.Cancelled() {
 		return nil
 	}
 
 	lectern.Page = page
-	p.tx.SetBlock(pos, lectern, nil)
+	p.Tx().SetBlock(pos, lectern, nil)
 	return nil
 }
 
@@ -3001,7 +2985,7 @@ func (p *Player) updateState() {
 func (p *Player) Breathing() bool {
 	_, breathing := p.Effect(effect.WaterBreathing)
 	_, conduitPower := p.Effect(effect.ConduitPower)
-	_, submerged := p.tx.Liquid(cube.PosFromVec3(entity.EyePosition(p)))
+	_, submerged := p.Tx().Liquid(cube.PosFromVec3(entity.EyePosition(p)))
 	return !p.GameMode().AllowsTakingDamage() || !submerged || breathing || conduitPower
 }
 
@@ -3032,12 +3016,12 @@ func (p *Player) PunchAir() {
 	if p.Dead() {
 		return
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandlePunchAir(ctx); ctx.Cancelled() {
 		return
 	}
 	p.SwingArm()
-	p.tx.PlaySound(p.Position(), sound.Attack{})
+	p.Tx().PlaySound(p.Position(), sound.Attack{})
 }
 
 // UpdateDiagnostics updates the diagnostics of the player.
@@ -3115,7 +3099,7 @@ func (p *Player) damageItem(s item.Stack, d int) item.Stack {
 	if p.GameMode().CreativeInventory() || d == 0 || s.MaxDurability() == -1 {
 		return s
 	}
-	ctx := NewEventContext(p.tx, p)
+	ctx := NewEventContext(p.Tx(), p)
 	if p.Handler().HandleItemDamage(ctx, s, &d); ctx.Cancelled() || d <= 0 {
 		return s
 	}
@@ -3123,7 +3107,7 @@ func (p *Player) damageItem(s item.Stack, d int) item.Stack {
 		d = enchantment.Unbreaking.Reduce(s.Item(), e.Level(), d)
 	}
 	if s = s.Damage(d); s.Empty() {
-		p.tx.PlaySound(p.Position(), sound.ItemBreak{})
+		p.Tx().PlaySound(p.Position(), sound.ItemBreak{})
 	}
 	return s
 }
@@ -3213,14 +3197,14 @@ func (p *Player) quit(msg string) {
 		// Close the session on this owner directly: teardown must not depend
 		// on the session goroutine, which cannot schedule work anymore once
 		// the world starts closing.
-		s.Close(p.tx, p)
+		s.Close(p.Tx(), p)
 		s.CloseConnection()
 		return
 	}
 	// Only remove the player from the world if it's not attached to a session. If it is attached to a session, the
 	// session will remove the player once ready.
-	p.tx.RemoveEntity(p)
-	_ = p.handle.Close()
+	p.Tx().RemoveEntity(p)
+	_ = p.H().Close()
 }
 
 // Data returns the player data that needs to be saved. This is used when the player
@@ -3254,7 +3238,7 @@ func (p *Player) Data() Config {
 		OffHand:             p.offHand,
 		Armour:              p.armour,
 		EnderChestInventory: p.enderChest,
-		FireTicks:           p.fireTicks,
+		FireTicks:           int64(p.OnFireDuration() / (time.Second / 20)),
 		FallDistance:        p.fallDistance,
 		Effects:             p.Effects(),
 	}
@@ -3338,7 +3322,7 @@ func (p *Player) broadcastArmour(_ int, before, after item.Stack) {
 
 // viewers returns a list of all viewers of the Player.
 func (p *Player) viewers() []world.Viewer {
-	viewers := p.tx.Viewers(p.Position())
+	viewers := p.Tx().Viewers(p.Position())
 	var s world.Viewer = p.session()
 	if slices.Index(viewers, s) == -1 && p.s != nil {
 		return append(viewers, p.s)
@@ -3384,10 +3368,10 @@ func (p *Player) resendNearbyBlock(pos cube.Pos) {
 		// to allocate memory for chunks, potentially exhausting RAM.
 		return
 	}
-	b := p.tx.Block(pos)
+	b := p.Tx().Block(pos)
 	p.session().ViewBlockUpdate(pos, b, 0)
 	if _, ok := b.(world.LiquidDisplacer); ok {
-		liq, _ := p.tx.Liquid(pos)
+		liq, _ := p.Tx().Liquid(pos)
 		p.session().ViewBlockUpdate(pos, liq, 1)
 	}
 }

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -85,8 +85,7 @@ type playerData struct {
 
 	lastXPPickup *time.Time
 
-	lastDamage  float64
-	immuneUntil time.Time
+	immunity entity.AttackImmunity
 
 	deathPos       *mgl64.Vec3
 	deathDimension world.Dimension
@@ -629,11 +628,9 @@ func (p *Player) Hurt(dmg float64, src world.DamageSource) (float64, bool) {
 	totalDamage := p.FinalDamageFrom(dmg, src)
 	damageLeft := totalDamage
 
-	immune := time.Now().Before(p.immuneUntil)
-	if immune {
-		if damageLeft -= p.lastDamage; damageLeft <= 0 {
-			return 0, false
-		}
+	damageLeft, immune := p.immunity.Reduce(damageLeft)
+	if immune && damageLeft <= 0 {
+		return 0, false
 	}
 
 	immunity := time.Second / 2
@@ -641,7 +638,7 @@ func (p *Player) Hurt(dmg float64, src world.DamageSource) (float64, bool) {
 	if p.Handler().HandleHurt(ctx, &damageLeft, immune, &immunity, src); ctx.Cancelled() {
 		return 0, false
 	}
-	p.setAttackImmunity(immunity, totalDamage)
+	p.immunity.Arm(immunity, totalDamage)
 
 	if a := p.Absorption(); a > 0 {
 		remaining := a - damageLeft
@@ -771,12 +768,6 @@ func (p *Player) KnockBack(src mgl64.Vec3, force, height float64) {
 func (p *Player) knockBack(src mgl64.Vec3, force, height float64) {
 	velocity := entity.KnockBackVector(p.Position(), src, force, height)
 	p.SetVelocity(velocity.Mul(1 - p.Armour().KnockBackResistance()))
-}
-
-// setAttackImmunity sets the duration the player is immune to entity attacks.
-func (p *Player) setAttackImmunity(d time.Duration, dmg float64) {
-	p.immuneUntil = time.Now().Add(d)
-	p.lastDamage = dmg
 }
 
 // Food returns the current food level of a player. The level returned is guaranteed to always be between 0

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -111,14 +111,11 @@ type playerData struct {
 // Player is an implementation of a player entity. It has methods that implement the behaviour that players
 // need to play in the world.
 type Player struct {
+	*entity.Ent
 	tx     *world.Tx
 	handle *world.EntityHandle
 	data   *world.EntityData
 	*playerData
-}
-
-func (p *Player) H() *world.EntityHandle {
-	return p.handle
 }
 
 func (p *Player) Tx() *world.Tx {
@@ -2337,17 +2334,6 @@ func (p *Player) Displace(deltaPos mgl64.Vec3) {
 	p.updateFallState(deltaPos[1])
 }
 
-// Position returns the current position of the player. It may be changed as the player moves or is moved
-// around the world.
-func (p *Player) Position() mgl64.Vec3 {
-	return p.data.Pos
-}
-
-// Velocity returns the players current velocity. If there is an attached session, this will be empty.
-func (p *Player) Velocity() mgl64.Vec3 {
-	return p.data.Vel
-}
-
 // SetVelocity updates the player's velocity. If there is an attached session, this will just send
 // the velocity to the player session for the player to update.
 func (p *Player) SetVelocity(velocity mgl64.Vec3) {
@@ -2358,13 +2344,6 @@ func (p *Player) SetVelocity(velocity mgl64.Vec3) {
 	for _, v := range p.viewers() {
 		v.ViewEntityVelocity(p, velocity)
 	}
-}
-
-// Rotation returns the yaw and pitch of the player in degrees. Yaw is horizontal rotation (rotation around the
-// vertical axis, 0 when facing forward), pitch is vertical rotation (rotation around the horizontal axis, also 0
-// when facing forward).
-func (p *Player) Rotation() cube.Rotation {
-	return p.data.Rot
 }
 
 // Collect makes the player collect the item stack passed, adding it to the inventory. The amount of items that could
@@ -2595,6 +2574,7 @@ func (p *Player) Tick(tx *world.Tx, current int64) {
 
 	p.checkBlockCollisions(p.data.Vel)
 	p.onGround = p.checkOnGround(mgl64.Vec3{})
+	p.Ent.Data().Age += time.Second / 20
 	p.checkEntitySteppers()
 
 	p.effects.Tick(p, p.tx)
@@ -3023,6 +3003,18 @@ func (p *Player) Breathing() bool {
 	_, conduitPower := p.Effect(effect.ConduitPower)
 	_, submerged := p.tx.Liquid(cube.PosFromVec3(entity.EyePosition(p)))
 	return !p.GameMode().AllowsTakingDamage() || !submerged || breathing || conduitPower
+}
+
+// UpdateState resends the player's metadata to all viewers of the player.
+func (p *Player) UpdateState() {
+	p.updateState()
+}
+
+// PlayAction plays a world.EntityAction for all viewers of the player.
+func (p *Player) PlayAction(a world.EntityAction) {
+	for _, v := range p.viewers() {
+		v.ViewEntityAction(p, a)
+	}
 }
 
 // SwingArm makes the player swing its arm.

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -736,7 +736,7 @@ func (p *Player) FinalDamageFrom(dmg float64, src world.DamageSource) float64 {
 func (p *Player) Explode(src world.ExplosionSource, impact float64) {
 	explosionPos := src.Position()
 	diff := p.Position().Sub(explosionPos)
-	p.Hurt(math.Floor((impact*impact+impact)*3.5*src.Size()*2+1), entity.ExplosionDamageSource{Source: src})
+	p.Hurt(entity.ExplosionDamage(src.Size(), impact), entity.ExplosionDamageSource{Source: src})
 	p.knockBack(explosionPos, impact, diff[1]/diff.Len()*impact)
 }
 

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/df-mc/dragonfly/server/block"
 	"github.com/df-mc/dragonfly/server/block/cube"
-	"github.com/df-mc/dragonfly/server/block/model"
 	"github.com/df-mc/dragonfly/server/cmd"
 	"github.com/df-mc/dragonfly/server/entity"
 	"github.com/df-mc/dragonfly/server/entity/effect"
@@ -69,9 +68,7 @@ type playerData struct {
 	fireTicks    int64
 	fallDistance float64
 
-	breathing         bool
-	airSupplyTicks    int
-	maxAirSupplyTicks int
+	air *entity.AirSupply
 
 	cooldowns map[string]time.Time
 
@@ -1992,7 +1989,7 @@ func (p *Player) breakTime(pos cube.Pos) time.Duration {
 func (p *Player) breakContext() block.BreakContext {
 	_, aquaAffinity := p.Armour().Helmet().Enchantment(enchantment.AquaAffinity)
 	ctx := block.BreakContext{
-		Underwater:   p.insideOfWater(),
+		Underwater:   entity.Submerged(p, p.tx),
 		AquaAffinity: aquaAffinity,
 		Airborne:     !p.OnGround(),
 		Flying:       p.Flying(),
@@ -2653,7 +2650,7 @@ func (p *Player) Tick(tx *world.Tx, current int64) {
 	if p.Position()[1] < float64(p.tx.Range()[0]) {
 		p.Hurt(4, entity.VoidDamageSource{})
 	}
-	if p.insideOfSolid() {
+	if entity.InsideOfSolid(p, p.tx) {
 		p.Hurt(1, entity.SuffocationDamageSource{})
 	}
 
@@ -2769,20 +2766,11 @@ func (p *Player) RemoveViewLayer(entity world.Entity) {
 
 // tickAirSupply tick's the player's air supply, consuming it when underwater, and replenishing it when out of water.
 func (p *Player) tickAirSupply() {
-	if !p.canBreathe() {
-		if r, ok := p.Armour().Helmet().Enchantment(enchantment.Respiration); ok && rand.Float64() < enchantment.Respiration.Chance(r.Level()) {
-			// respiration grants a chance to avoid drowning damage every tick.
-			return
-		}
-		if p.airSupplyTicks -= 1; p.airSupplyTicks <= -20 {
-			p.airSupplyTicks = 0
-			p.Hurt(2, entity.DrowningDamageSource{})
-		}
-		p.breathing = false
-		p.updateState()
-	} else if !p.breathing && p.airSupplyTicks < p.maxAirSupplyTicks {
-		p.airSupplyTicks = min(p.airSupplyTicks+5, p.maxAirSupplyTicks)
-		p.breathing = p.airSupplyTicks == p.maxAirSupplyTicks
+	drowned, changed := p.air.Tick(p.canBreathe(), p.Armour().Helmet())
+	if drowned {
+		p.Hurt(2, entity.DrowningDamageSource{})
+	}
+	if changed {
 		p.updateState()
 	}
 }
@@ -2839,23 +2827,23 @@ func (p *Player) starve() {
 
 // AirSupply returns the player's remaining air supply.
 func (p *Player) AirSupply() time.Duration {
-	return time.Duration(p.airSupplyTicks) * time.Second / 20
+	return p.air.Supply()
 }
 
 // SetAirSupply sets the player's remaining air supply.
 func (p *Player) SetAirSupply(duration time.Duration) {
-	p.airSupplyTicks = int(duration.Milliseconds() / 50)
+	p.air.SetSupply(duration)
 	p.updateState()
 }
 
 // MaxAirSupply returns the player's maximum air supply.
 func (p *Player) MaxAirSupply() time.Duration {
-	return time.Duration(p.maxAirSupplyTicks) * time.Second / 20
+	return p.air.Max()
 }
 
 // SetMaxAirSupply sets the player's maximum air supply.
 func (p *Player) SetMaxAirSupply(duration time.Duration) {
-	p.maxAirSupplyTicks = int(duration.Milliseconds() / 50)
+	p.air.SetMax(duration)
 	p.updateState()
 }
 
@@ -2864,52 +2852,7 @@ func (p *Player) canBreathe() bool {
 	canTakeDamage := p.GameMode().AllowsTakingDamage()
 	_, waterBreathing := p.effects.Effect(effect.WaterBreathing)
 	_, conduitPower := p.effects.Effect(effect.ConduitPower)
-	return !canTakeDamage || waterBreathing || conduitPower || (!p.insideOfWater() && !p.insideOfSolid())
-}
-
-// breathingDistanceBelowEyes is the lowest distance the player can be in water and still be able to breathe based on
-// the player's eye height.
-const breathingDistanceBelowEyes = 0.11111111
-
-// insideOfWater returns true if the player is currently underwater.
-func (p *Player) insideOfWater() bool {
-	pos := cube.PosFromVec3(entity.EyePosition(p))
-	if l, ok := p.tx.Liquid(pos); ok {
-		if _, ok := l.(block.Water); ok {
-			d := float64(l.SpreadDecay()) + 1
-			if l.LiquidFalling() {
-				d = 1
-			}
-			return p.Position().Y() < (pos.Side(cube.FaceUp).Vec3().Y())-(d/9-breathingDistanceBelowEyes)
-		}
-	}
-	return false
-}
-
-// insideOfSolid returns true if the player is inside a solid block.
-func (p *Player) insideOfSolid() bool {
-	pos := cube.PosFromVec3(entity.EyePosition(p))
-	b, box := p.tx.Block(pos), p.handle.Type().BBox(p).Translate(p.Position())
-
-	_, solid := b.Model().(model.Solid)
-	if !solid {
-		// Not solid.
-		return false
-	}
-	d, diffuses := b.(block.LightDiffuser)
-	if diffuses && d.LightDiffusionLevel() == 0 {
-		// Transparent.
-		return false
-	}
-	if immune, ok := b.(block.NonSuffocating); ok && immune.PreventsSuffocation() {
-		return false
-	}
-	for _, blockBox := range b.Model().BBox(pos, p.tx) {
-		if blockBox.Translate(pos.Vec3()).IntersectsWith(box) {
-			return true
-		}
-	}
-	return false
+	return !canTakeDamage || waterBreathing || conduitPower || (!entity.Submerged(p, p.tx) && !entity.InsideOfSolid(p, p.tx))
 }
 
 // checkCollisions checks the player's block collisions.
@@ -3355,8 +3298,8 @@ func (p *Player) Data() Config {
 		Food:                p.hunger.foodLevel,
 		Exhaustion:          p.hunger.exhaustionLevel,
 		Saturation:          p.hunger.saturationLevel,
-		AirSupply:           p.airSupplyTicks,
-		MaxAirSupply:        p.maxAirSupplyTicks,
+		AirSupply:           int(p.air.Supply() / (time.Second / 20)),
+		MaxAirSupply:        int(p.air.Max() / (time.Second / 20)),
 		EnchantmentSeed:     p.enchantSeed,
 		Experience:          p.experience.Experience(),
 		HeldSlot:            int(*p.heldSlot),

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -769,14 +769,7 @@ func (p *Player) KnockBack(src mgl64.Vec3, force, height float64) {
 // knockBack is an unexported function that is used to knock the player back. This function does not check if the player
 // can take damage or not.
 func (p *Player) knockBack(src mgl64.Vec3, force, height float64) {
-	velocity := p.Position().Sub(src)
-	velocity[1] = 0
-
-	if velocity.Len() != 0 {
-		velocity = velocity.Normalize().Mul(force)
-	}
-	velocity[1] = height
-
+	velocity := entity.KnockBackVector(p.Position(), src, force, height)
 	p.SetVelocity(velocity.Mul(1 - p.Armour().KnockBackResistance()))
 }
 

--- a/server/player/player.go
+++ b/server/player/player.go
@@ -568,46 +568,7 @@ func (p *Player) updateFallState(distanceThisTick float64) {
 
 // fall is called when a falling entity hits the ground.
 func (p *Player) fall(distance float64) {
-	if pos, lander, ok := p.landedOn(); ok {
-		lander.EntityLand(pos, p.tx, p, &distance)
-	}
-	dmg := distance - 3
-	if boost, ok := p.Effect(effect.JumpBoost); ok {
-		dmg -= float64(boost.Level())
-	}
-	if dmg < 0.5 {
-		return
-	}
-	p.Hurt(math.Ceil(dmg), entity.FallDamageSource{})
-}
-
-// landedOn returns the first block.EntityLander the Player came to rest on, along with its position.
-func (p *Player) landedOn() (cube.Pos, block.EntityLander, bool) {
-	low, high := p.blocksUnder()
-	for x := low[0]; x <= high[0]; x++ {
-		for z := low[2]; z <= high[2]; z++ {
-			pos := cube.Pos{x, low[1], z}
-			if lander, ok := p.tx.Block(pos).(block.EntityLander); ok {
-				return pos, lander, true
-			}
-		}
-	}
-	return cube.Pos{}, nil, false
-}
-
-// blocksUnder returns the corners of the range of block positions directly below the Player. Every block in that range
-// is one the Player stands on: the Player is narrower than a block, so it may rest on the edge of one with its centre
-// over the block beside it, and looking only below its centre would miss the block it is actually standing on.
-func (p *Player) blocksUnder() (low, high cube.Pos) {
-	box := Type.BBox(p).Translate(p.Position())
-	// The Y is taken from the box itself, while the horizontal range is taken from a slightly smaller box so that a
-	// Player resting exactly on the boundary between two blocks does not reach into the column beside the one it
-	// stands on.
-	y := int(math.Floor(box.Min()[1] - 0.0001))
-	horizontal := box.Grow(-0.0001)
-	low, high = cube.PosFromVec3(horizontal.Min()), cube.PosFromVec3(horizontal.Max())
-	low[1], high[1] = y, y
-	return low, high
+	entity.Fall(p, p.tx, p.effects, distance)
 }
 
 // Hurt hurts the player for a given amount of damage. The source passed

--- a/server/player/ref.go
+++ b/server/player/ref.go
@@ -37,7 +37,7 @@ func (p *Player) Do(f func(tx *world.Tx, p *Player)) *world.Task {
 	if p == nil {
 		return world.NewFinishedTask(world.ErrEntityClosed)
 	}
-	return Do(p.handle, f)
+	return Do(p.H(), f)
 }
 
 // DoAfter schedules f on the player's current world owner after delay.
@@ -45,5 +45,5 @@ func (p *Player) DoAfter(delay time.Duration, f func(tx *world.Tx, p *Player)) *
 	if p == nil {
 		return world.NewFinishedTask(world.ErrEntityClosed)
 	}
-	return DoAfter(p.handle, delay, f)
+	return DoAfter(p.H(), delay, f)
 }

--- a/server/player/type.go
+++ b/server/player/type.go
@@ -2,6 +2,7 @@ package player
 
 import (
 	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/entity"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 )
@@ -14,6 +15,7 @@ type ptype struct{}
 func (t ptype) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
 	pd := data.Data.(*playerData)
 	p := &Player{
+		Ent:        entity.Open(tx, handle, data),
 		tx:         tx,
 		handle:     handle,
 		data:       data,

--- a/server/player/type.go
+++ b/server/player/type.go
@@ -14,13 +14,7 @@ type ptype struct{}
 
 func (t ptype) Open(tx *world.Tx, handle *world.EntityHandle, data *world.EntityData) world.Entity {
 	pd := data.Data.(*playerData)
-	p := &Player{
-		Ent:        entity.Open(tx, handle, data),
-		tx:         tx,
-		handle:     handle,
-		data:       data,
-		playerData: pd,
-	}
+	p := &Player{Ent: entity.Open(tx, handle, data), playerData: pd}
 
 	pd.offHand.SlotValidatorFunc(func(s item.Stack, _ int) bool {
 		if s.Empty() {

--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -40,6 +40,11 @@ func (s *Session) parseEntityMetadata(e world.Entity) protocol.EntityMetadata {
 	if ent, ok := e.(interface{ Behaviour() entity.Behaviour }); ok {
 		if b := ent.Behaviour(); b != nil {
 			s.addSpecificMetadata(b, m)
+			// A Behaviour may contribute raw metadata of its own by implementing EncodeEntityMetadata. It
+			// runs last so it may override the generic metadata above.
+			if enc, ok := b.(interface{ EncodeEntityMetadata(m map[uint32]any) }); ok {
+				enc.EncodeEntityMetadata(m)
+			}
 		}
 	}
 	return m

--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -37,8 +37,10 @@ func (s *Session) parseEntityMetadata(e world.Entity) protocol.EntityMetadata {
 		m.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagLingering)
 	}
 	s.addSpecificMetadata(e, m)
-	if ent, ok := e.(*entity.Ent); ok {
-		s.addSpecificMetadata(ent.Behaviour(), m)
+	if ent, ok := e.(interface{ Behaviour() entity.Behaviour }); ok {
+		if b := ent.Behaviour(); b != nil {
+			s.addSpecificMetadata(b, m)
+		}
 	}
 	return m
 }

--- a/server/session/world.go
+++ b/server/session/world.go
@@ -119,14 +119,17 @@ func (s *Session) ViewEntity(e world.Entity) {
 			s.ViewSkin(e)
 		}
 		return
-	case *entity.Ent:
+	case interface {
+		Behaviour() entity.Behaviour
+		Velocity() mgl64.Vec3
+	}:
 		switch e.H().Type() {
 		case entity.ItemType:
 			s.writePacket(&packet.AddItemActor{
 				EntityUniqueID:  int64(runtimeID),
 				EntityRuntimeID: runtimeID,
 				Item:            instanceFromItem(s.br, v.Behaviour().(*entity.ItemBehaviour).Item()),
-				Position:        vec64To32(v.Position()),
+				Position:        vec64To32(e.Position()),
 				Velocity:        vec64To32(v.Velocity()),
 				EntityMetadata:  metadata,
 			})

--- a/server/world/handler.go
+++ b/server/world/handler.go
@@ -63,6 +63,10 @@ type Handler interface {
 	// HandleEntityDespawn handles an Entity being despawned from a World
 	// through a call to Tx.RemoveEntity.
 	HandleEntityDespawn(tx *Tx, e Entity)
+	// HandleEntityHurt handles damage about to be dealt to any entity in the world other than a player,
+	// which is handled by its own Handler instead. ctx.Cancel() may be called to cancel the damage
+	// entirely, and the damage may be changed through the pointer passed.
+	HandleEntityHurt(ctx *Context, e Entity, damage *float64, src DamageSource)
 	// HandleExplosion handles an explosion in the world. ctx.Cancel() may be called
 	// to cancel the explosion.
 	// The affected entities, affected blocks, item drop chance, and whether the
@@ -98,6 +102,7 @@ func (NopHandler) HandlePortalCreate(*Context, Dimension, []cube.Pos)           
 func (NopHandler) HandlePortalActivate(*Context, Dimension, []cube.Pos)         {}
 func (NopHandler) HandleEntitySpawn(*Tx, Entity)                                {}
 func (NopHandler) HandleEntityDespawn(*Tx, Entity)                              {}
+func (NopHandler) HandleEntityHurt(*Context, Entity, *float64, DamageSource)    {}
 func (NopHandler) HandleExplosion(*Context, ExplosionSource, *[]Entity, *[]cube.Pos, *float64, *bool) {
 }
 func (NopHandler) HandleRedstoneUpdate(*Context, RedstoneUpdate) {}

--- a/server/world/redstone_test.go
+++ b/server/world/redstone_test.go
@@ -20,6 +20,7 @@ func runWorld(w *World, f func(*Tx)) {
 }
 
 func (minimalRedstoneTestHandler) HandleRedstoneUpdate(*Context, RedstoneUpdate)                {}
+func (minimalRedstoneTestHandler) HandleEntityHurt(*Context, Entity, *float64, DamageSource)    {}
 func (minimalRedstoneTestHandler) HandleLiquidFlow(*Context, cube.Pos, cube.Pos, Liquid, Block) {}
 func (minimalRedstoneTestHandler) HandleLiquidDecay(*Context, cube.Pos, Liquid, Liquid)         {}
 func (minimalRedstoneTestHandler) HandleLiquidHarden(*Context, cube.Pos, Block, Block, Block)   {}


### PR DESCRIPTION
This is the substance of #1450, with the bug fixes and the UI change pulled out into their own PRs.

A player is an entity, but almost nothing that makes an entity alive sits on the entity side. Damage, armour, effects, air, fall handling, fire ticks, knockback and attack immunity all live on Player, and it's the same logic anything else alive would need, so anything that isn't a player has to duplicate it and the two copies drift apart. This moves that into shared pieces and has the player use them like anything else would: LivingEnt and LivingState as a base, AirSupply and AttackImmunity as components to embed, and FinalDamage, KnockBackVector, ExplosionDamage and Fall as plain functions. Living splits into Damageable and EffectBearer, and player.go gets a good deal shorter along the way.

HandleEntityHurt comes with it because it can't go in alone. There's no single place entity damage passes through upstream, since Hurt sits on Living and every entity implements it itself, so the hook would have nothing to hook into. The shared damage path is what gives it one.