### PR TITLE
 server/entity, server/session: Fix four entity bugs

### DIFF
--- a/server/entity/end_crystal_behaviour.go
+++ b/server/entity/end_crystal_behaviour.go
@@ -46,9 +46,13 @@ func (b endCrystalBehaviour) Explode(e *Ent, _ world.ExplosionSource, impact flo
 }
 
 // Hurt makes the End crystal explode when damaged by any source, even by
-// damage that deals no health. Void damage removes it without an explosion.
+// damage that deals no health. End crystals are immune to fire damage, and
+// void damage removes them without an explosion.
 func (b endCrystalBehaviour) Hurt(e *Ent, damage float64, src world.DamageSource) (float64, bool) {
 	damage = max(damage, 0)
+	if src.Fire() {
+		return 0, false
+	}
 	if _, ok := src.(VoidDamageSource); ok {
 		_ = e.Close()
 		return damage, true

--- a/server/entity/lightning.go
+++ b/server/entity/lightning.go
@@ -20,6 +20,12 @@ func NewLightning(opts world.EntitySpawnOpts) *world.EntityHandle {
 // NewLightningWithDamage creates a new lightning entities using the damage and
 // fire properties passed.
 func NewLightningWithDamage(opts world.EntitySpawnOpts, dmg float64, blockFire bool, entityFireDuration time.Duration) *world.EntityHandle {
+	return opts.New(LightningType, lightningStrikeConf(dmg, blockFire, entityFireDuration))
+}
+
+// lightningStrikeConf returns the StationaryBehaviourConfig of a lightning bolt with the damage and fire
+// properties passed bound to its Tick.
+func lightningStrikeConf(dmg float64, blockFire bool, entityFireDuration time.Duration) StationaryBehaviourConfig {
 	conf := lightningConf
 	conf.Tick = (&lightningState{
 		Damage:             dmg,
@@ -28,7 +34,7 @@ func NewLightningWithDamage(opts world.EntitySpawnOpts, dmg float64, blockFire b
 		state:              2,
 		lifetime:           rand.IntN(4) + 1,
 	}).tick
-	return opts.New(LightningType, conf)
+	return conf
 }
 
 var lightningConf = StationaryBehaviourConfig{SpawnSounds: []world.Sound{sound.Explosion{}, sound.Thunder{}}, ExistenceDuration: time.Second}
@@ -85,9 +91,8 @@ func (s *lightningState) dealDamage(e *Ent, tx *world.Tx) {
 // 4 additional attempts to spread it around that position.
 func (s *lightningState) spreadFire(tx *world.Tx, pos cube.Pos) {
 	s.fire().Start(tx, pos)
-	for i := 0; i < 4; i++ {
-		pos.Add(cube.Pos{rand.IntN(3) - 1, rand.IntN(3) - 1, rand.IntN(3) - 1})
-		s.fire().Start(tx, pos)
+	for range 4 {
+		s.fire().Start(tx, pos.Add(cube.Pos{rand.IntN(3) - 1, rand.IntN(3) - 1, rand.IntN(3) - 1}))
 	}
 }
 
@@ -118,7 +123,9 @@ func (t lightningType) Open(tx *world.Tx, handle *world.EntityHandle, data *worl
 	return &Ent{tx: tx, handle: handle, data: data}
 }
 func (t lightningType) DecodeNBT(_ map[string]any, data *world.EntityData) {
-	data.Data = lightningConf.New()
+	// Lightning stores no NBT of its own: recreate the default strike so a bolt
+	// loaded from disk still deals damage and starts fire.
+	data.Data = lightningStrikeConf(5, true, time.Second*8).New()
 }
 func (t lightningType) EncodeNBT(*world.EntityData) map[string]any { return nil }
 func (lightningType) EncodeEntity() string                         { return "minecraft:lightning_bolt" }

--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -89,7 +89,7 @@ func (s *Session) addSpecificMetadata(e any, m protocol.EntityMetadata) {
 			m.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagHasCollision)
 		}
 	}
-	if o, ok := e.(orb); ok {
+	if o, ok := e.(orb); ok && metadataAllowedFor(e, entity.ExperienceOrbType) {
 		m[protocol.EntityDataKeyValue] = int32(o.Experience())
 	}
 	if f, ok := e.(firework); ok {
@@ -346,4 +346,12 @@ type variable interface {
 
 type markVariable interface {
 	MarkVariant() int32
+}
+
+// metadataAllowedFor reports whether metadata read from e may be sent: e either is no world.Entity, or an
+// entity of the world.EntityType passed. It filters metadata that a Behaviour reports through a method
+// another entity kind happens to share.
+func metadataAllowedFor(e any, t world.EntityType) bool {
+	ent, ok := e.(world.Entity)
+	return !ok || ent.H().Type() == t
 }

--- a/server/session/entity_metadata.go
+++ b/server/session/entity_metadata.go
@@ -84,10 +84,14 @@ func (s *Session) addSpecificMetadata(e any, m protocol.EntityMetadata) {
 	if c, ok := e.(arrow); ok && c.Critical() {
 		m.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagCritical)
 	}
+	// Everything the world resolves against blocks says so, not only a player.
+	// A game mode without collision, spectator, still takes it away.
+	collides := true
 	if g, ok := e.(gameMode); ok {
-		if g.GameMode().HasCollision() {
-			m.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagHasCollision)
-		}
+		collides = g.GameMode().HasCollision()
+	}
+	if collides {
+		m.SetFlag(protocol.EntityDataKeyFlags, protocol.EntityDataFlagHasCollision)
 	}
 	if o, ok := e.(orb); ok && metadataAllowedFor(e, entity.ExperienceOrbType) {
 		m[protocol.EntityDataKeyValue] = int32(o.Experience())


### PR DESCRIPTION
**Four unrelated fixes I ran into while working on entities:**

1. A lightning bolt decoded from disk was given lightningConf.New(), and lightningConf carries no Tick, so the bolt dealt no damage and started no fire. It now gets the same strike NewLightning creates. In the same entity, spreadFire threw away the result of pos.Add, which returns a new position rather than moving the one passed, so all four extra attempts lit the block the bolt had already hit instead of spreading around it.

2. An End crystal exploded when set on fire. The vanilla definition gives it minecraft:fire_immune, so fire is turned away before the explosion now.

3. The experience orb metadata was written for anything carrying an Experience method, and *player.Player carries one, so every player had its own experience written into the orb field of its metadata.

4. And the collision flag was set only for an entity carrying a game mode, which is to say only for a player, so no mob ever reported that it meets a block. A packet capture of BDS shows it set on everything, an experience orb included.