### PR TITLE
Fix registry cloning panic in compound block hashes

### DIFF
--- a/cmd/blockhash/main.go
+++ b/cmd/blockhash/main.go
@@ -142,7 +142,8 @@ func (b *hashBuilder) writeBlockHash(w io.Writer) {
 func hashBlock(b world.Block) uint64 {
 	base, state := b.Hash()
 	if base > 0xffff || state > 0xffff {
-		panic("material block hash exceeds 16-bit type or state")
+		name, _ := b.EncodeBlock()
+		panic("hash of block " + name + " exceeds 16-bit type or state")
 	}
 	return base | state<<16
 }

--- a/cmd/blockhash/main.go
+++ b/cmd/blockhash/main.go
@@ -56,6 +56,7 @@ func procPackage(pkg *packages.Package, w io.Writer) {
 	b.writePackage(w)
 	b.writeConstants(w)
 	b.writeNextHash(w)
+	b.writeBlockHash(w)
 	b.writeMethods(w)
 }
 
@@ -129,6 +130,24 @@ func (b *hashBuilder) writeNextHash(w io.Writer) {
 		log.Fatalln(err)
 	}
 	if _, err := fmt.Fprintln(w, "func NextHash() uint64 {\n\tcustomBlockBase++\n\treturn customBlockBase\n}"); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+// writeBlockHash writes the registry-independent hash used for material blocks.
+func (b *hashBuilder) writeBlockHash(w io.Writer) {
+	const helper = `
+// hashBlock packs a material block's type and state into the 32 bits reserved by generated hashes.
+// Each half uses 16 bits so the result does not depend on a registry's size or initialization.
+func hashBlock(b world.Block) uint64 {
+	base, state := b.Hash()
+	if base > 0xffff || state > 0xffff {
+		panic("material block hash exceeds 16-bit type or state")
+	}
+	return base | state<<16
+}
+`
+	if _, err := fmt.Fprint(w, helper); err != nil {
 		log.Fatalln(err)
 	}
 }
@@ -237,7 +256,7 @@ func (b *hashBuilder) ftype(structName, s string, expr ast.Expr, directives map[
 	case "int":
 		return "uint64(" + s + ")", 8
 	case "Block":
-		return "world.BlockHash(" + s + ")", 32
+		return "hashBlock(" + s + ")", 32
 	case "Attachment":
 		if _, ok := directives["facing_only"]; ok {
 			log.Println("Found directive: 'facing_only'")

--- a/server/block/block_behaviour_test.go
+++ b/server/block/block_behaviour_test.go
@@ -2,6 +2,8 @@ package block_test
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/df-mc/dragonfly/server/block"
@@ -9,6 +11,46 @@ import (
 	"github.com/df-mc/dragonfly/server/entity"
 	"github.com/df-mc/dragonfly/server/world"
 )
+
+// TestBlockRegistryBeforeDefaultFinalization verifies that independent registries can be finalized
+// before the default registry and keep their block lookups when it is finalized later.
+func TestBlockRegistryBeforeDefaultFinalization(t *testing.T) {
+	const childEnv = "DRAGONFLY_TEST_REGISTRY_CHILD"
+	if os.Getenv(childEnv) != "1" {
+		// Use a fresh process so other tests cannot finalize the default registry first.
+		cmd := exec.Command(os.Args[0], "-test.run=^TestBlockRegistryBeforeDefaultFinalization$")
+		cmd.Env = append(os.Environ(), childEnv+"=1")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("registry subprocess failed: %v\n%s", err, output)
+		}
+		return
+	}
+
+	block.NextHash()
+	registries := []world.BlockRegistry{world.DefaultBlockRegistry.Clone(), world.NewBlockRegistry()}
+	for _, registry := range registries {
+		registry.Finalize()
+	}
+	blocks := registries[0].Blocks()
+	hashes := make([][2]uint64, len(blocks))
+	for rid, b := range blocks {
+		base, state := b.Hash()
+		hashes[rid] = [2]uint64{base, state}
+	}
+
+	world.DefaultBlockRegistry.Finalize()
+	for rid, b := range blocks {
+		base, state := b.Hash()
+		if got := [2]uint64{base, state}; got != hashes[rid] {
+			t.Fatalf("hash of %T changed after default finalization: %v != %v", b, got, hashes[rid])
+		}
+		for _, registry := range registries {
+			if got := registry.BlockRuntimeID(b); got != uint32(rid) {
+				t.Fatalf("runtime ID of %T = %d, want %d", b, got, rid)
+			}
+		}
+	}
+}
 
 // TestTorchBreaksWithoutSupport verifies that a torch is broken by a neighbour
 // update on the tick after its supporting block is removed, using a

--- a/server/block/block_behaviour_test.go
+++ b/server/block/block_behaviour_test.go
@@ -2,8 +2,6 @@ package block_test
 
 import (
 	"context"
-	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/df-mc/dragonfly/server/block"
@@ -11,46 +9,6 @@ import (
 	"github.com/df-mc/dragonfly/server/entity"
 	"github.com/df-mc/dragonfly/server/world"
 )
-
-// TestBlockRegistryBeforeDefaultFinalization verifies that independent registries can be finalized
-// before the default registry and keep their block lookups when it is finalized later.
-func TestBlockRegistryBeforeDefaultFinalization(t *testing.T) {
-	const childEnv = "DRAGONFLY_TEST_REGISTRY_CHILD"
-	if os.Getenv(childEnv) != "1" {
-		// Use a fresh process so other tests cannot finalize the default registry first.
-		cmd := exec.Command(os.Args[0], "-test.run=^TestBlockRegistryBeforeDefaultFinalization$")
-		cmd.Env = append(os.Environ(), childEnv+"=1")
-		if output, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("registry subprocess failed: %v\n%s", err, output)
-		}
-		return
-	}
-
-	block.NextHash()
-	registries := []world.BlockRegistry{world.DefaultBlockRegistry.Clone(), world.NewBlockRegistry()}
-	for _, registry := range registries {
-		registry.Finalize()
-	}
-	blocks := registries[0].Blocks()
-	hashes := make([][2]uint64, len(blocks))
-	for rid, b := range blocks {
-		base, state := b.Hash()
-		hashes[rid] = [2]uint64{base, state}
-	}
-
-	world.DefaultBlockRegistry.Finalize()
-	for rid, b := range blocks {
-		base, state := b.Hash()
-		if got := [2]uint64{base, state}; got != hashes[rid] {
-			t.Fatalf("hash of %T changed after default finalization: %v != %v", b, got, hashes[rid])
-		}
-		for _, registry := range registries {
-			if got := registry.BlockRuntimeID(b); got != uint32(rid) {
-				t.Fatalf("runtime ID of %T = %d, want %d", b, got, rid)
-			}
-		}
-	}
-}
 
 // TestTorchBreaksWithoutSupport verifies that a torch is broken by a neighbour
 // update on the tick after its supporting block is removed, using a

--- a/server/block/hash.go
+++ b/server/block/hash.go
@@ -236,6 +236,16 @@ func NextHash() uint64 {
 	return customBlockBase
 }
 
+// hashBlock packs a material block's type and state into the 32 bits reserved by generated hashes.
+// Each half uses 16 bits so the result does not depend on a registry's size or initialization.
+func hashBlock(b world.Block) uint64 {
+	base, state := b.Hash()
+	if base > 0xffff || state > 0xffff {
+		panic("material block hash exceeds 16-bit type or state")
+	}
+	return base | state<<16
+}
+
 func (Air) Hash() (uint64, uint64) {
 	return hashAir, 0
 }
@@ -965,7 +975,7 @@ func (s Skull) Hash() (uint64, uint64) {
 }
 
 func (s Slab) Hash() (uint64, uint64) {
-	return hashSlab, world.BlockHash(s.Block) | uint64(boolByte(s.Top))<<32 | uint64(boolByte(s.Double))<<33
+	return hashSlab, hashBlock(s.Block) | uint64(boolByte(s.Top))<<32 | uint64(boolByte(s.Double))<<33
 }
 
 func (Slime) Hash() (uint64, uint64) {
@@ -1017,7 +1027,7 @@ func (t StainedTerracotta) Hash() (uint64, uint64) {
 }
 
 func (s Stairs) Hash() (uint64, uint64) {
-	return hashStairs, world.BlockHash(s.Block) | uint64(boolByte(s.UpsideDown))<<32 | uint64(s.Facing)<<33
+	return hashStairs, hashBlock(s.Block) | uint64(boolByte(s.UpsideDown))<<32 | uint64(s.Facing)<<33
 }
 
 func (s Stone) Hash() (uint64, uint64) {
@@ -1077,7 +1087,7 @@ func (v Vines) Hash() (uint64, uint64) {
 }
 
 func (w Wall) Hash() (uint64, uint64) {
-	return hashWall, world.BlockHash(w.Block) | uint64(w.NorthConnection.Uint8())<<32 | uint64(w.EastConnection.Uint8())<<34 | uint64(w.SouthConnection.Uint8())<<36 | uint64(w.WestConnection.Uint8())<<38 | uint64(boolByte(w.Post))<<40
+	return hashWall, hashBlock(w.Block) | uint64(w.NorthConnection.Uint8())<<32 | uint64(w.EastConnection.Uint8())<<34 | uint64(w.SouthConnection.Uint8())<<36 | uint64(w.WestConnection.Uint8())<<38 | uint64(boolByte(w.Post))<<40
 }
 
 func (w Water) Hash() (uint64, uint64) {

--- a/server/block/hash.go
+++ b/server/block/hash.go
@@ -241,7 +241,8 @@ func NextHash() uint64 {
 func hashBlock(b world.Block) uint64 {
 	base, state := b.Hash()
 	if base > 0xffff || state > 0xffff {
-		panic("material block hash exceeds 16-bit type or state")
+		name, _ := b.EncodeBlock()
+		panic("hash of block " + name + " exceeds 16-bit type or state")
 	}
 	return base | state<<16
 }

--- a/server/block/wall.go
+++ b/server/block/wall.go
@@ -1,14 +1,12 @@
 package block
 
 import (
-	"fmt"
 	"github.com/df-mc/dragonfly/server/block/cube"
 	"github.com/df-mc/dragonfly/server/block/model"
 	"github.com/df-mc/dragonfly/server/internal/sliceutil"
 	"github.com/df-mc/dragonfly/server/item"
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/go-gl/mathgl/mgl64"
-	"math"
 )
 
 // Wall is a block similar to fences that prevents players from jumping over and is thinner than the usual block. It is
@@ -247,10 +245,6 @@ func (w Wall) calculatePost(tx *world.Tx, pos cube.Pos) (Wall, bool) {
 // allWalls returns a list of all wall types.
 func allWalls() (walls []world.Block) {
 	for _, block := range WallBlocks() {
-		if _, hash := block.Hash(); hash > math.MaxUint16 {
-			name, _ := block.EncodeBlock()
-			panic(fmt.Errorf("hash of block %s exceeds 16 bytes", name))
-		}
 		for _, north := range WallConnectionTypes() {
 			for _, east := range WallConnectionTypes() {
 				for _, south := range WallConnectionTypes() {


### PR DESCRIPTION
Finalizing `world.DefaultBlockRegistry.Clone()` or `world.NewBlockRegistry()` before the default registry panics with duplicate block hashes. Generated stairs, slab, and wall hashes encode their material through `world.BlockHash()`, which reads the default registry's uninitialized bit width. Oak and spruce stairs then collide even without calling `block.NextHash()`.

Generate a registry-independent material hash with separate 16-bit type and state fields and checked bounds. This also replaces the wall-only state bound.

Validation:
- Reproduced the reported panic before the fix and verified the standalone reproduction succeeds afterward.
- `go test ./...`
- `make lint` (0 issues)
- `go generate ./server/block/` followed by `git diff --exit-code`
